### PR TITLE
case prefix is not overridden to None in run_driver and run_model.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -701,12 +701,10 @@ class Problem(object):
             raise RuntimeError(self.msginfo +
                                ": The `setup` method must be called before `run_model`.")
 
-        if case_prefix:
+        if case_prefix is not None:
             if not isinstance(case_prefix, str):
                 raise TypeError(self.msginfo + ": The 'case_prefix' argument should be a string.")
             self._recording_iter.prefix = case_prefix
-        else:
-            self._recording_iter.prefix = None
 
         if self.model.iter_count > 0 and reset_iter_counts:
             self.driver.iter_count = 0
@@ -741,12 +739,10 @@ class Problem(object):
             raise RuntimeError(self.msginfo +
                                ": The `setup` method must be called before `run_driver`.")
 
-        if case_prefix:
+        if case_prefix is not None:
             if not isinstance(case_prefix, str):
                 raise TypeError(self.msginfo + ": The 'case_prefix' argument should be a string.")
             self._recording_iter.prefix = case_prefix
-        else:
-            self._recording_iter.prefix = None
 
         if self.model.iter_count > 0 and reset_iter_counts:
             self.driver.iter_count = 0
@@ -758,6 +754,7 @@ class Problem(object):
         record_model_options(self, self._run_counter)
 
         self.model._clear_iprint()
+
         return self.driver.run()
 
     def compute_jacvec_product(self, of, wrt, mode, seed):

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -33,9 +33,17 @@ class _RecIteration(object):
             The rank to use when constructing iteration coordinates.
         """
         self.stack = []
-        self.prefix = None
+        self._prefix = None
         self.rank = 0
         self._norec_refcount = 0
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+    @prefix.setter
+    def prefix(self, s):
+        self._prefix = s
 
     def print_recording_iteration_stack(self):
         """


### PR DESCRIPTION
### Summary

Test changing `Problem.run_model` and `Problem.run_driver` such that they don't change the _RecIteration `prefix` property if one is not specified.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
