### PR TITLE
Changed default design variable behavior to 'raise' by default.

### DIFF
--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -17,7 +17,7 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.setup()
 
         # check derivatives
-        prob['y1'] = 100
+        prob['y1'] = 4
         prob['equal.rhs:y1'] = 1
 
         prob.run_model()
@@ -157,7 +157,7 @@ class TestEQConstraintComp(unittest.TestCase):
         diff = lhs - rhs
         assert_near_equal(prob['equal.y'], diff)
 
-        prob.driver = om.ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False, invalid_desvar_behavior='ignore')
 
         prob.run_driver()
 
@@ -274,7 +274,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         prob.setup(mode='fwd')
 
-        prob.driver = om.ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False, invalid_desvar_behavior='ignore')
 
         # verify that the output is not being normalized
         prob.run_model()

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1173,6 +1173,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.pyOptSparseDriver(optimizer=OPTIMIZER)
+        p.driver.options['invalid_desvar_behavior'] = 'ignore'
 
         mm = om.MetaModelStructuredComp(extrapolate=False)
         mm.add_input('x', val=1.0, training_data=x_tr)

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -115,7 +115,8 @@ class Driver(object):
                                   "iteration.",
                              default=[])
 
-        default_desvar_behavior = os.environ.get('OPENMDAO_INVALID_DESVAR_BEHAVIOR', 'warn').lower()
+        default_desvar_behavior = os.environ.get('OPENMDAO_INVALID_DESVAR_BEHAVIOR',
+                                                 'raise').lower()
 
         self.options.declare('invalid_desvar_behavior', values=('warn', 'raise', 'ignore'),
                              desc='Behavior of driver if the initial value of a design '

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -1089,7 +1089,7 @@ class MPITestDifferentialEvolution4Procs(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', om.IndepVarComp('x', 3.0), promotes=['x'])
+        model.add_subsystem('p', om.IndepVarComp('x', 0.5), promotes=['x'])
 
         model.add_subsystem('d1', D1(), promotes=['*'])
         model.add_subsystem('d2', D2(), promotes=['*'])

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -226,8 +226,8 @@ class TestSimpleGA(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 1.25, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 2.05, units='cm**2'), promotes=['*'])
         model.add_subsystem('xc_a3', om.IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
         model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 1), promotes=['*'])
         model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 1), promotes=['*'])
@@ -294,11 +294,11 @@ class TestSimpleGA(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 1.25, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 2.05, units='cm**2'), promotes=['*'])
         model.add_subsystem('xc_a3', om.IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 1), promotes=['*'])
-        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 1), promotes=['*'])
+        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 3), promotes=['*'])
+        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 3), promotes=['*'])
         model.add_subsystem('xi_m3', om.IndepVarComp('mat3', 1), promotes=['*'])
         model.add_subsystem('comp', ThreeBarTruss(), promotes=['*'])
         model.add_subsystem('obj_with_penalty', ObjPenalty(), promotes=['*'])
@@ -1171,11 +1171,11 @@ class MPITestSimpleGA(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 1.25, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 2.05, units='cm**2'), promotes=['*'])
         model.add_subsystem('xc_a3', om.IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 1), promotes=['*'])
-        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 1), promotes=['*'])
+        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 3), promotes=['*'])
+        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 3), promotes=['*'])
         model.add_subsystem('xi_m3', om.IndepVarComp('mat3', 1), promotes=['*'])
         model.add_subsystem('comp', ThreeBarTruss(), promotes=['*'])
         model.add_subsystem('obj_with_penalty', ObjPenalty(), promotes=['*'])

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -1447,6 +1447,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         driver.options['max_gen'] = 3
         driver.options['run_parallel'] = True
         driver.options['procs_per_model'] = 2
+        driver.options['invalid_desvar_behavior'] = 'ignore'
 
         # also check that parallel recording works
         driver.add_recorder(om.SqliteRecorder("cases.sql"))

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1732,7 +1732,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(2)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', -np.ones(2)), promotes=['*'])
         model.add_subsystem('func2d', Func2d(), promotes=['*'])
 
         prob.driver = driver = om.ScipyOptimizeDriver()
@@ -1881,7 +1881,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(size)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', -np.ones(size)), promotes=['*'])
         model.add_subsystem('rastrigin', Rastrigin(), promotes=['*'])
 
         prob.driver = driver = om.ScipyOptimizeDriver()

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1240,7 +1240,7 @@ class TestSqliteRecorder(unittest.TestCase):
         nl.add_recorder(self.recorder)
 
         prob['indeps.x'] = 2.
-        prob['indeps.z'] = [-1., -1.]
+        prob['indeps.z'] = [1., 1.]
 
         prob.run_driver()
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2919,7 +2919,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(metadata['name'], 'DOEDriver')
         self.assertEqual(metadata['type'], 'doe')
         self.assertEqual(metadata['options'], {'debug_print': [], 'generator': 'UniformGenerator',
-                                               'invalid_desvar_behavior': 'warn',
+                                               'invalid_desvar_behavior': 'raise',
                                                'run_parallel': False, 'procs_per_model': 1})
 
         # Optimization
@@ -2939,7 +2939,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(metadata['type'], 'optimization')
         self.assertEqual(metadata['options'], {"debug_print": [], "optimizer": "SLSQP",
                                                "tol": 1e-03, "maxiter": 200, "disp": True,
-                                               "invalid_desvar_behavior": "warn",
+                                               "invalid_desvar_behavior": "raise",
                                                 'singular_jac_behavior': 'warn', 'singular_jac_tol': 1e-16})
         self.assertEqual(metadata['opt_settings'], {"maxiter": 1000})
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1225,6 +1225,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-8
+        prob.driver.options['invalid_desvar_behavior'] = 'ignore'
 
         prob.set_solver_print(level=0)
 

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -195,7 +195,7 @@ class TestBetzLimit(unittest.TestCase):
         prob.setup()
 
         prob.set_val('a', .5)
-        prob.set_val('Area', 10.0, units='m**2')
+        prob.set_val('Area', 1.0, units='m**2')
         prob.set_val('rho', 1.225, units='kg/m**3')
         prob.set_val('Vu', 10.0, units='m/s')
 
@@ -302,7 +302,7 @@ class TestBetzLimit(unittest.TestCase):
         prob = om.Problem()
         indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('a', .5, tags="advanced")
-        indeps.add_output('Area', 10.0, units='m**2', tags="basic")
+        indeps.add_output('Area', 1.0, units='m**2', tags="basic")
         indeps.add_output('rho', 1.225, units='kg/m**3', tags="advanced")
         indeps.add_output('Vu', 10.0, units='m/s', tags="basic")
 


### PR DESCRIPTION
### Summary

The recently implemented `OPENMDAO_INVALID_DESVAR_BEHAVIOR` environment variable was initially treated as having a default value of 'warn'.  This behavior is being changed to default to 'raise'.

### Related Issues

- Resolves #

### Backwards incompatibilities

Models which previously encountered a warning with invalid design variable initial values will now cause an exception.
User's may also set this option at the driver level with `driver.options['invalid_desvar_behavior'] = 'warn'` (or set the environment variable) to retain the previous behavior.

### New Dependencies

None
