### PR TITLE
Fixed a bug where using approx_totals without explicitly declared partials resulted in relevance and singular jacobian errors.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -959,7 +959,7 @@ class Driver(object):
             if subsys._has_approx:
                 if self.options['singular_jac_behavior'] == 'warn':
                     issue_warning(f'System {subsys} has approximated derivatives.'
-                                ' Relevance check skipped.', DriverWarning)
+                                  ' Relevance check skipped.', DriverWarning)
                 return
 
         relevant = problem.model._relevant
@@ -993,7 +993,7 @@ class Driver(object):
                    "not depend on any design variables. "
                    "Please check your problem formulation.")
             if self.options['singular_jac_behavior'] == 'warn':
-                om.issue_warning(msg, DriverWarning)
+                issue_warning(msg, DriverWarning)
             elif self.options['singular_jac_behavior'] == 'error':
                 raise RuntimeError(msg)
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -869,8 +869,8 @@ class Group(System):
                     break
             else:
                 msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
-                    " be impacted by the design variables of the problem because no partials "
-                    "were defined for them in their parent component(s).")
+                       " be impacted by the design variables of the problem because no partials "
+                       "were defined for them in their parent component(s).")
                 if self._problem_meta['singular_jac_behavior'] == 'error':
                     raise RuntimeError(msg)
                 else:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -864,13 +864,17 @@ class Group(System):
                     missing_responses.add(output)
 
         if missing_responses:
-            msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
-                   " be impacted by the design variables of the problem because no partials "
-                   "were defined for them in their parent component(s).")
-            if self._problem_meta['singular_jac_behavior'] == 'error':
-                raise RuntimeError(msg)
+            for subsys in self.system_iter(include_self=True, recurse=True):
+                if subsys._has_approx:
+                    break
             else:
-                issue_warning(msg, category=DerivativesWarning)
+                msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
+                    " be impacted by the design variables of the problem because no partials "
+                    "were defined for them in their parent component(s).")
+                if self._problem_meta['singular_jac_behavior'] == 'error':
+                    raise RuntimeError(msg)
+                else:
+                    issue_warning(msg, category=DerivativesWarning)
 
         self._relevance_graph = graph
         return graph

--- a/openmdao/core/tests/test_semitotals.py
+++ b/openmdao/core/tests/test_semitotals.py
@@ -199,6 +199,7 @@ class FakeGeomComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare("n", types=int)
+        self.options.declare('declare_partials', types=(bool,), default=True)
 
     def setup(self):
         n = self.options["n"]
@@ -206,7 +207,8 @@ class FakeGeomComp(om.ExplicitComponent):
         self.add_input("feather", val=0.0, units="deg")
         self.add_output("x", val=np.zeros(n), units="m")
 
-        self.declare_partials("*", "*", method="fd")
+        if self.options['declare_partials']:
+            self.declare_partials("*", "*", method="fd")
 
         self._counter = 0
 
@@ -222,6 +224,7 @@ class FakeAeroComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare("n", types=int)
+        self.options.declare('declare_partials', types=(bool,), default=True)
 
     def setup(self):
         n = self.options["n"]
@@ -232,7 +235,8 @@ class FakeAeroComp(om.ExplicitComponent):
         self.add_output("CT", val=0.5)
         self.add_output("CP", val=0.5)
 
-        self.declare_partials("*", "*", method="fd")
+        if self.options['declare_partials']:
+            self.declare_partials("*", "*", method="fd")
 
         self._counter = 0
 
@@ -251,15 +255,19 @@ class GeometryAndAero2(om.Group):
         self.options.declare("n", types=int)
         self.options.declare("rho", types=float)
         self.options.declare("vinf", types=float)
+        self.options.declare('declare_partials', types=(bool,), default=True)
 
     def setup(self):
         n = self.options["n"]
+        dp = self.options['declare_partials']
 
         comp = self.add_subsystem("init_geom", om.IndepVarComp(), promotes_outputs=["x0"])
         comp.add_output("x0", val=np.arange(n) + 1.0, units="m")
 
-        self.add_subsystem("geom", FakeGeomComp(n=n), promotes_inputs=["x0", "feather"], promotes_outputs=["x"])
-        self.add_subsystem("aero", FakeAeroComp(n=n), promotes_inputs=["x", "omega"], promotes_outputs=["CT", "CP"])
+        self.add_subsystem("geom", FakeGeomComp(n=n, declare_partials=dp),
+                           promotes_inputs=["x0", "feather"], promotes_outputs=["x"])
+        self.add_subsystem("aero", FakeAeroComp(n=n, declare_partials=dp),
+                           promotes_inputs=["x", "omega"], promotes_outputs=["CT", "CP"])
 
     def reset_count(self):
         self.geom._counter = 0
@@ -310,3 +318,47 @@ class TestSemiTotalsNumCalls(unittest.TestCase):
         assert_check_totals(data, atol=1e-6, rtol=1e-6)
 
         self.assertEqual(geom_and_aero.geom._counter, 4)
+
+    def test_check_relevlance_approx_totals(self):
+
+        for behavior in ['error']:
+            with self.subTest(f'Checking relevance with approx_totals and singular_jac_behavior = {behavior}'):
+                size = 10
+                rho = 1.17573
+                minf = 0.111078231621482
+                speedofsound = 344.5760217432
+                vinf = minf*speedofsound
+
+                prob = om.Problem()
+                prob.driver = om.ScipyOptimizeDriver(singular_jac_behavior=behavior)
+                prob.driver.options["optimizer"] = "SLSQP"
+
+                omega = 7199.759242*2*np.pi/60
+                ivc = prob.model.add_subsystem("ivc", om.IndepVarComp(), promotes_outputs=["*"])
+                ivc.add_output("feather", val=0.0, units="deg")
+                ivc.add_output("omega", val=omega, units="rad/s")
+
+                geom_and_aero = prob.model.add_subsystem('geom_and_aero',
+                                                        GeometryAndAero2(n=size, rho=rho, vinf=vinf, declare_partials=False),
+                                                        promotes_inputs=["feather", "omega"],
+                                                        promotes_outputs=["CT", "CP"])
+                geom_and_aero.approx_totals(step=step, step_calc="abs", method="fd", form="forward")
+
+                prob.model.add_design_var("feather", lower=-5.0, upper=25.0, units="deg", ref=1.0)
+                prob.model.add_design_var("omega", lower=3000*2*np.pi/60, upper=7500*2*np.pi/60, units="rad/s", ref=1.0)
+                prob.model.add_objective("CP", ref=1e0)
+                prob.model.add_constraint("CT", lower=0.0)
+
+                prob.setup(force_alloc_complex=False)
+
+                omega = (6245.096992023524*2*np.pi/60) + step
+                feather = 0.6362159381168669
+                prob.set_val("omega", omega, units="rad/s")
+                prob.set_val("feather", feather, units="deg")
+                fail = prob.run_driver()
+
+                self.assertEqual(fail, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/core/tests/test_semitotals.py
+++ b/openmdao/core/tests/test_semitotals.py
@@ -321,7 +321,7 @@ class TestSemiTotalsNumCalls(unittest.TestCase):
 
     def test_check_relevlance_approx_totals(self):
 
-        for behavior in ['error']:
+        for behavior in ['ignore', 'warn', 'error']:
             with self.subTest(f'Checking relevance with approx_totals and singular_jac_behavior = {behavior}'):
                 size = 10
                 rho = 1.17573

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1727,7 +1727,6 @@ class _TotalJacInfo(object):
         raise_error : bool
             If True, raise an exception if a zero row or column is found.
         """
-        return
         nzrows, nzcols = np.nonzero(np.abs(self.J) > tol)
 
         # Check for zero rows, which correspond to constraints unaffected by any design vars.

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1727,6 +1727,7 @@ class _TotalJacInfo(object):
         raise_error : bool
             If True, raise an exception if a zero row or column is found.
         """
+        return
         nzrows, nzcols = np.nonzero(np.abs(self.J) > tol)
 
         # Check for zero rows, which correspond to constraints unaffected by any design vars.

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
@@ -325,6 +325,126 @@
     "\n",
     "assert_near_equal(derivs['z', 'x'], np.array([[300.]]), tolerance=1e-8)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9510c93",
+   "metadata": {},
+   "source": [
+    "(approx_totals_relevance)=\n",
+    "## Approx-Totals and Relevance\n",
+    "\n",
+    "OpenMDAO builds a relevancy-graph that helps it be more efficient when executing complex models.\n",
+    "\n",
+    "One feature that uses this graph is the `relevance check` that is performed when a Driver begins to run.\n",
+    "The relevance check is used to verify that each constraint can be impacted by a design variable.\n",
+    "\n",
+    "However, when `approx_totals` is used, users often omit the declaration of any partials.\n",
+    "In this situation, the relevance check would normally fail, so OpenMDAO skips this check if any subsystem\n",
+    "is found to use approximated derivatives.\n",
+    "\n",
+    "In this situation, the user will get a warning regarding this behavior. This warning may be disabled\n",
+    "by setting the driver option `driver.options['singular_jac_behavior'] = 'ignore'`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb70c742",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import openmdao.api as om\n",
+    "\n",
+    "class AComp(om.ExplicitComponent):\n",
+    "\n",
+    "    def setup(self):\n",
+    "        self.add_input('x', val=0.0)\n",
+    "        self.add_output('y', val=0.0)\n",
+    "\n",
+    "    def compute(self, inputs, outputs):\n",
+    "        outputs['y'] = inputs['x'] - 5.0\n",
+    "\n",
+    "class BComp(om.ExplicitComponent):\n",
+    "\n",
+    "    def setup(self):\n",
+    "        self.add_input('y', val=0.0)\n",
+    "        self.add_output('z', val=0.0)\n",
+    "\n",
+    "    def compute(self, inputs, outputs):\n",
+    "        outputs['z'] = inputs['y'] ** 2\n",
+    "\n",
+    "prob = om.Problem()\n",
+    "prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')\n",
+    "model = prob.model\n",
+    "model.set_input_defaults('x', 0.0)\n",
+    "\n",
+    "model.add_subsystem('a', AComp(), promotes=['x', 'y'])\n",
+    "model.add_subsystem('b', BComp(), promotes=['y', 'z'])\n",
+    "\n",
+    "model.add_design_var('x', lower=-100, upper=100)\n",
+    "model.add_objective('z')\n",
+    "\n",
+    "model.approx_totals(method='cs')\n",
+    "\n",
+    "prob.setup()\n",
+    "prob.run_driver()\n",
+    "\n",
+    "of = ['z']\n",
+    "wrt = ['x']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c771d4",
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(prob.get_val('x'), 5.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc5daa96",
+   "metadata": {},
+   "source": [
+    "We can silence this warning by setting driver option `singular_jac_behavior` to `ignore`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "903f6d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prob.driver.options['singular_jac_behavior'] = 'ignore'\n",
+    "prob.setup()\n",
+    "prob.run_driver()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fd637f7",
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(prob.get_val('x'), 5.0)"
+   ]
   }
  ],
  "metadata": {
@@ -344,7 +464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.4"
   },
   "orphan": true
  },

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -837,10 +837,16 @@ class pyOptSparseDriver(Driver):
                                                  return_format=self._total_jac_format)
 
                 # First time through, check for zero row/col.
+                singular_jac_behavior = self.options['singular_jac_behavior']
                 if self._check_jac and self._total_jac is not None:
-                    raise_error = self.options['singular_jac_behavior'] == 'error'
-                    self._total_jac.check_total_jac(raise_error=raise_error,
-                                                    tol=self.options['singular_jac_tol'])
+                    if singular_jac_behavior != 'ignore':
+                        raise_error = singular_jac_behavior == 'error'
+                        for subsys in model.subsys_iter(include_self=True, recurse=True):
+                            if subsys._has_approx:
+                                break
+                        else:
+                            self._total_jac.check_total_jac(raise_error=raise_error,
+                                                            tol=self.options['singular_jac_tol'])
                     self._check_jac = False
 
             # Let the optimizer try to handle the error

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -841,7 +841,7 @@ class pyOptSparseDriver(Driver):
                 if self._check_jac and self._total_jac is not None:
                     if singular_jac_behavior != 'ignore':
                         raise_error = singular_jac_behavior == 'error'
-                        for subsys in model.subsys_iter(include_self=True, recurse=True):
+                        for subsys in model.system_iter(include_self=True, recurse=True):
                             if subsys._has_approx:
                                 break
                         else:

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -725,10 +725,16 @@ class ScipyOptimizeDriver(Driver):
             self._grad_cache = grad
 
             # First time through, check for zero row/col.
+            singular_jac_behavior = self.options['singular_jac_behavior']
             if self._check_jac and self._total_jac is not None:
-                raise_error = self.options['singular_jac_behavior'] == 'error'
-                self._total_jac.check_total_jac(raise_error=raise_error,
-                                                tol=self.options['singular_jac_tol'])
+                if singular_jac_behavior != 'ignore':
+                    raise_error = singular_jac_behavior == 'error'
+                    for subsys in model.subsys_iter(include_self=True, recurse=True):
+                        if subsys._has_approx:
+                            break
+                    else:
+                        self._total_jac.check_total_jac(raise_error=raise_error,
+                                                        tol=self.options['singular_jac_tol'])
                 self._check_jac = False
 
         except Exception as msg:

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -719,6 +719,8 @@ class ScipyOptimizeDriver(Driver):
         ndarray
             Gradient of objective with respect to input array.
         """
+        prob = self._problem()
+        model = prob.model
         try:
             grad = self._compute_totals(of=self._obj_and_nlcons, wrt=self._dvlist,
                                         return_format=self._total_jac_format)
@@ -729,9 +731,9 @@ class ScipyOptimizeDriver(Driver):
             if self._check_jac and self._total_jac is not None:
                 if singular_jac_behavior != 'ignore':
                     raise_error = singular_jac_behavior == 'error'
-                    for subsys in model.subsys_iter(include_self=True, recurse=True):
+                    for subsys in model.system_iter(include_self=True, recurse=True):
                         if subsys._has_approx:
-                            break
+                            pass
                     else:
                         self._total_jac.check_total_jac(raise_error=raise_error,
                                                         tol=self.options['singular_jac_tol'])


### PR DESCRIPTION
### Summary

`approx_totals` resulted in an invalid relevance graph, and so the relevance check is now skipped when `approx_totals` is set for any system in the problem model.

The singular jacobian check in `Group` also is skipped if any system is found to use `approx_totals`.

Finally, `check_total_jac` has more detailed but similar checks that are now also skipped in the presense of `approx_totals`.

### Related Issues

- Resolves #3026 

### Backwards incompatibilities

None

### New Dependencies

None
