### PR TITLE
Implementation of a DriverResults object returned by run_driver.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -46,15 +46,15 @@ class DriverResult():
     """
 
     def __init__(self):
+        """
+        Initialize the DriverResult object.
+        """
         self.runtime = 0.0
         self.iter_count = 0
         self.obj_calls = 0
         self.deriv_calls = 0
         self.exit_status = 'NOT_RUN'
         self.success = False
-
-    def __getitem__(self, s):
-        return getattr(self, s)
 
 
 class Driver(object):
@@ -1451,10 +1451,9 @@ class Driver(object):
 
             return self._coloring_info.coloring
 
-    def _update_results(self):
+    def _update_results(self, results):
         """
-        Custom drivers should override this method to set any
-        additional attributes of opt_results.
+        Set additional attributes and information to the DriverResults.
         """
         pass
 
@@ -1518,7 +1517,7 @@ class SaveOptResult(object):
         driver.opt_result.exit_status = driver.get_exit_status()
 
         # The custom driver results
-        driver._update_results()
+        driver._update_results(driver.opt_results)
 
 
 class RecordingDebugging(Recording):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -26,6 +26,24 @@ from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, Driver
 
 
 class DriverResult():
+    """
+    A container that stores information pertaining to the result of a driver execution.
+
+    Attributes
+    ----------
+    runtime : float
+        The time required to execute the driver, in seconds.
+    iter_count : int
+        The number of iterations used by the optimizer.
+    obj_calls : int
+        The number of times the objective function was evaluated (model solve_nonlinear calls).
+    deriv_calls : int
+        The number of times the total jacobian was computed.
+    exit_status : str
+        A string that may provide more detail about the results of the driver run.
+    success : bool
+        A boolean that dictates whether or not the driver was successful.
+    """
 
     def __init__(self):
         self.runtime = 0.0
@@ -38,10 +56,6 @@ class DriverResult():
     def __getitem__(self, s):
         return getattr(self, s)
 
-    def __setitem__(self, s, val):
-        if not hasattr(self, s):
-            raise AttributeError(f'DriverResult has no attribute {s}.')
-        setattr(self, s, val)
 
 class Driver(object):
     """
@@ -617,11 +631,9 @@ class Driver(object):
             with SaveOptResult(self):
                 failed = self.run()
 
-        self.opt_result['success'] = not failed
+        self.opt_result.success = not failed
 
         return self.opt_result
-
-
 
     def _get_voi_val(self, name, meta, remote_vois, driver_scaling=True,
                      get_remote=True, rank=None):
@@ -1446,6 +1458,7 @@ class Driver(object):
         """
         pass
 
+
 class SaveOptResult(object):
     """
     A context manager that saves details about a driver run.
@@ -1498,11 +1511,11 @@ class SaveOptResult(object):
         driver = self._driver
 
         # The standard driver results
-        driver.opt_result['runtime'] = time.perf_counter() - self._start_time
-        driver.opt_result['iter_count'] = driver.iter_count
-        driver.opt_result['obj_calls'] = driver.get_driver_objective_calls()
-        driver.opt_result['deriv_calls'] = driver.get_driver_derivative_calls()
-        driver.opt_result['exit_status'] = driver.get_exit_status()
+        driver.opt_result.runtime = time.perf_counter() - self._start_time
+        driver.opt_result.iter_count = driver.iter_count
+        driver.opt_result.obj_calls = driver.get_driver_objective_calls()
+        driver.opt_result.deriv_calls = driver.get_driver_derivative_calls()
+        driver.opt_result.exit_status = driver.get_exit_status()
 
         # The custom driver results
         driver._update_results()

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1517,7 +1517,7 @@ class SaveOptResult(object):
         driver.opt_result.exit_status = driver.get_exit_status()
 
         # The custom driver results
-        driver._update_results(driver.opt_results)
+        driver._update_results(driver.opt_result)
 
 
 class RecordingDebugging(Recording):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -56,6 +56,25 @@ class DriverResult():
         self.exit_status = 'NOT_RUN'
         self.success = False
 
+    def __getitem__(self, s):
+        """
+        Provide key access to the attributes of DriverResult.
+
+        This is included for backward compatibility with some
+        tests which require dictionary-like access.
+
+        Parameters
+        ----------
+        s : str
+            The name of the attribute.
+
+        Returns
+        -------
+        object
+            The value of the attribute
+        """
+        return getattr(self, s)
+
 
 class Driver(object):
     """

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -637,8 +637,8 @@ class Driver(object):
 
         Returns
         -------
-        dict
-            optimization_result dict, containing information about the run.
+        DriverResult
+            DriverResult object, containing information about the run.
         """
         problem = self._problem()
         model = problem.model

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -109,8 +109,6 @@ class Driver(object):
 
     Attributes
     ----------
-    fail : bool
-        Reports whether the driver ran successfully.
     iter_count : int
         Keep track of iterations for case recording.
     options : <OptionsDictionary>
@@ -160,8 +158,8 @@ class Driver(object):
         Cached total jacobian handling object.
     _total_jac_linear : _TotalJacInfo or None
         Cached linear total jacobian handling object.
-    opt_result : dict
-        Dictionary containing information for use in the optimization report.
+    result : dict
+        DriverResult object containing information for use in the optimization report.
     _has_scaling : bool
         If True, scaling has been set for this driver.
     """

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -1275,7 +1275,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.setup(mode='fwd')
 
-        failed = prob.run_driver()
+        prob.run_driver()
 
         totals = prob.check_totals(out_stream=None)
 
@@ -1309,8 +1309,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.setup(mode='rev')
 
-        failed = prob.run_driver()
-        print(failed)
+        result = prob.run_driver()
 
         totals = prob.check_totals(out_stream=None)
 

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -793,7 +793,7 @@ class TestDriver(unittest.TestCase):
         prob.set_val('sub.x', 50.)
         prob.set_val('sub.y', 50.)
 
-        failed = prob.run_driver()
+        result = prob.run_driver()
 
         assert_near_equal(prob['sub.x'], 6.66666667, 1e-6)
         assert_near_equal(prob['sub.y'], -7.3333333, 1e-6)
@@ -918,7 +918,7 @@ class TestCheckRelevance(unittest.TestCase):
 
         # add constraint that does not depend on a design var
         prob.model.add_constraint('bad', equals=-15.0)
-        
+
         prob.driver.options['singular_jac_behavior'] = 'error'
 
         prob.setup()

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -350,7 +350,7 @@ class ProbRemote4TestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         all_failed = comm.allgather(failed)
         if any(all_failed):

--- a/openmdao/core/tests/test_semitotals.py
+++ b/openmdao/core/tests/test_semitotals.py
@@ -354,9 +354,9 @@ class TestSemiTotalsNumCalls(unittest.TestCase):
             feather = 0.6362159381168669
             prob.set_val("omega", omega, units="rad/s")
             prob.set_val("feather", feather, units="deg")
-            fail = prob.run_driver()
+            result = prob.run_driver()
 
-            self.assertEqual(fail, False)
+            self.assertTrue(result.success)
 
 
 if __name__ == '__main__':

--- a/openmdao/docs/openmdao_book/examples/betz_limit.ipynb
+++ b/openmdao/docs/openmdao_book/examples/betz_limit.ipynb
@@ -81,7 +81,7 @@
     "                        desc=\"Thrust produced by the rotor\")\n",
     "        self.add_output('Cp', 0.0, desc=\"Power Coefficient\")\n",
     "        self.add_output('power', 0.0, units=\"W\", desc=\"Power produced by the rotor\")\n",
-    "        \n",
+    "\n",
     "        # Every output depends on `a`\n",
     "        self.declare_partials(of='*', wrt='a', method='cs')\n",
     "\n",
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fail = prob.run_driver()"
+    "result = prob.run_driver()"
    ]
   },
   {

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -37,6 +37,10 @@ class DOEDriver(Driver):
         List of design variables, used to compute derivatives.
     _quantities : list
         Contains the objectives plus nonlinear constraints, used to compute derivatives.
+    _num_model_evals : int
+        The number of times the Driver called model.solve_nonlinear.
+    _num_deriv_evals : int
+        The number of times the Driver called Driver._compute_totals.
     """
 
     def __init__(self, generator=None, **kwargs):

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -73,6 +73,8 @@ class DOEDriver(Driver):
         self._name = ''
         self._problem_comm = None
         self._color = None
+        self._num_model_evals = 0
+        self._num_deriv_evals = 0
 
         self._indep_list = []
         self._quantities = []
@@ -228,6 +230,8 @@ class DOEDriver(Driver):
                 metadata['success'] = 0
                 metadata['msg'] = traceback.format_exc()
                 print(metadata['msg'])
+            finally:
+                self._num_model_evals += 1
 
             # save reference to metadata for use in record_iteration
             self._metadata = metadata
@@ -237,6 +241,7 @@ class DOEDriver(Driver):
                                  wrt=self._indep_list,
                                  return_format=self._total_jac_format,
                                  driver_scaling=False)
+            self._num_deriv_evals += 1
 
     def _parallel_generator(self, design_vars, model=None):
         """
@@ -304,3 +309,25 @@ class DOEDriver(Driver):
         """
         self._metadata['name'] = case_name
         return self._metadata
+
+    def get_driver_objective_calls(self):
+        """
+        Return the number of times the model was evaluated during run.
+
+        Returns
+        -------
+        int
+            The number of calls to model.solve_nonlinear.
+        """
+        return self._num_model_evals
+
+    def get_driver_derivative_calls(self):
+        """
+        Return the number of times the total derivatives were evaluated during the run.
+
+        Returns
+        -------
+        int
+            The number of calls to _compute_totals.
+        """
+        return self._num_deriv_evals

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -151,7 +151,7 @@ class ScipyOptimizeDriver(Driver):
         # The user places optimizer-specific settings in here.
         self.opt_settings = {}
 
-        self.result = None
+        self._scipy_optimize_result = None
         self._grad_cache = None
         self._con_cache = None
         self._con_idx = {}
@@ -250,8 +250,8 @@ class ScipyOptimizeDriver(Driver):
         int
             Number of objective evaluations made during a driver run.
         """
-        if self.result and hasattr(self.result, 'nfev'):
-            return self.result.nfev
+        if self._scipy_optimize_result and hasattr(self._scipy_optimize_result, 'nfev'):
+            return self._scipy_optimize_result.nfev
         else:
             return None
 
@@ -264,8 +264,8 @@ class ScipyOptimizeDriver(Driver):
         int
             Number of derivative evaluations made during a driver run.
         """
-        if self.result and hasattr(self.result, 'njev'):
-            return self.result.njev
+        if self._scipy_optimize_result and hasattr(self._scipy_optimize_result, 'njev'):
+            return self._scipy_optimize_result.njev
         else:
             return None
 
@@ -585,7 +585,7 @@ class ScipyOptimizeDriver(Driver):
         if self._exc_info is not None:
             self._reraise()
 
-        self.result = result
+        self._scipy_optimize_result = result
 
         if hasattr(result, 'success'):
             self.fail = not result.success

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -101,7 +101,7 @@ class ScipyOptimizeDriver(Driver):
         Flag that indicates failure of most recent optimization.
     iter_count : int
         Counter for function evaluations.
-    result : OptimizeResult
+    _scipy_optimize_result : OptimizeResult
         Result returned from scipy.optimize call.
     opt_settings : dict
         Dictionary of solver-specific options. See the scipy.optimize.minimize documentation.

--- a/openmdao/drivers/tests/test_analysis_errors.py
+++ b/openmdao/drivers/tests/test_analysis_errors.py
@@ -215,7 +215,7 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
         #
         try:
             prob, comp = self.setup_problem(optimizer)
-            failed = prob.run_driver()
+            failed = not prob.run_driver().success
         except ImportError as err:
             raise unittest.SkipTest(str(err))
 
@@ -238,7 +238,7 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
         # Now try raising Analysis Errors in compute()
         #
         prob, comp = self.setup_problem(optimizer, func='compute')
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         expected_result = self.expected_result_eval_errors[optimizer]
         opt_inform = prob.driver.pyopt_solution.optInform
@@ -279,7 +279,7 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
         #
         try:
             prob, comp = self.setup_problem(optimizer)
-            failed = prob.run_driver()
+            failed = not prob.run_driver().success
         except ImportError as err:
             raise unittest.SkipTest(str(err))
 
@@ -303,7 +303,7 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
         #
         try:
             prob, comp = self.setup_problem(optimizer, func='compute_partials')
-            failed = prob.run_driver()
+            failed = not prob.run_driver().success
         except ImportError as err:
             raise unittest.SkipTest(str(err))
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1511,7 +1511,7 @@ class TestDOEDriver(unittest.TestCase):
         prob.driver.recording_options['record_derivatives'] = True
 
         prob.setup()
-        prob.run_driver()
+        result = prob.run_driver()
         prob.cleanup()
 
         expected_vals = self.expected_fullfact3
@@ -1530,6 +1530,13 @@ class TestDOEDriver(unittest.TestCase):
             derivs = cr.get_case(case).derivatives
             for dv in ('x', 'y'):
                 self.assertEqual(derivs['f_xy', dv], expected_deriv['f_xy', dv])
+
+        self.assertGreater(result.runtime, 1.0E-16)
+        self.assertEqual(result.iter_count, 9)
+        self.assertEqual(result.obj_calls, 9)
+        self.assertEqual(result.deriv_calls, 9)
+        self.assertEqual(result.success, True)
+        self.assertEqual(result.exit_status, 'SUCCESS')
 
     def test_derivative_no_recording(self):
         prob = om.Problem()

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1588,10 +1588,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        result, output = run_driver(prob)
+        fail, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed, info = " +
-                        str(prob.driver.pyopt_solution.optInform))
+        self.assertFalse(fail, "Optimization failed, info = " +
+                         str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('f_xy', [0])" in output)
@@ -1622,10 +1622,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        result, output = run_driver(prob)
+        fail, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed, info = " +
-                        str(prob.driver.pyopt_solution.optInform))
+        self.assertFalse(fail, "Optimization failed, info = " +
+                         str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('y', [1])" in output)

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -304,7 +304,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -348,7 +348,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -383,7 +383,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -417,7 +417,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -459,7 +459,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -494,7 +494,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -526,7 +526,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -557,7 +557,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -647,7 +647,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -679,7 +679,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -739,7 +739,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -781,7 +781,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -816,7 +816,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -856,7 +856,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -961,7 +961,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -996,7 +996,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1030,7 +1030,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1063,7 +1063,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1096,7 +1096,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1130,7 +1130,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1164,7 +1164,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1197,7 +1197,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1230,7 +1230,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1263,7 +1263,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1293,7 +1293,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1401,7 +1401,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -1517,10 +1517,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed, info = " +
-                                 str(prob.driver.pyopt_solution.optInform))
+        self.assertTrue(result.success, "Optimization failed, info = " +
+                        str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('f_xy', [0])" in output)
@@ -1551,10 +1551,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed, info = " +
-                             str(prob.driver.pyopt_solution.optInform))
+        self.assertTrue(result.success, "Optimization failed, info = " +
+                        str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('y', [1])" in output)
@@ -1588,10 +1588,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed, info = " +
-                                 str(prob.driver.pyopt_solution.optInform))
+        self.assertTrue(result.success, "Optimization failed, info = " +
+                        str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('f_xy', [0])" in output)
@@ -1622,10 +1622,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed, info = " +
-                             str(prob.driver.pyopt_solution.optInform))
+        self.assertTrue(result.success, "Optimization failed, info = " +
+                        str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('y', [1])" in output)
@@ -1658,10 +1658,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed, info = " +
-                                 str(prob.driver.pyopt_solution.optInform))
+        self.assertTrue(result.success, "Optimization failed, info = " +
+                        str(prob.driver.pyopt_solution.optInform))
 
         output = output.split('\n')
 
@@ -3027,7 +3027,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -3067,7 +3067,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed =  not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
@@ -3187,10 +3187,10 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed, info = " +
-                                 str(prob.driver.pyopt_solution.optInform))
+        self.assertTrue(result.success, "Optimization failed, info = " +
+                        str(prob.driver.pyopt_solution.optInform))
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['z'][1], 0.0, 1e-3)

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1517,10 +1517,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        result, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed, info = " +
-                        str(prob.driver.pyopt_solution.optInform))
+        self.assertFalse(failed, "Optimization failed, info = " +
+                         str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('f_xy', [0])" in output)
@@ -1551,10 +1551,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        result, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed, info = " +
-                        str(prob.driver.pyopt_solution.optInform))
+        self.assertFalse(failed, "Optimization failed, info = " +
+                         str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('y', [1])" in output)
@@ -1588,9 +1588,9 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        fail, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertFalse(fail, "Optimization failed, info = " +
+        self.assertFalse(failed, "Optimization failed, info = " +
                          str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: rev.' in output)
@@ -1622,9 +1622,9 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        fail, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertFalse(fail, "Optimization failed, info = " +
+        self.assertFalse(failed, "Optimization failed, info = " +
                          str(prob.driver.pyopt_solution.optInform))
 
         self.assertTrue('In mode: fwd.' in output)
@@ -1658,10 +1658,10 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        result, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed, info = " +
-                        str(prob.driver.pyopt_solution.optInform))
+        self.assertFalse(failed, "Optimization failed, info = " +
+                         str(prob.driver.pyopt_solution.optInform))
 
         output = output.split('\n')
 
@@ -3187,10 +3187,10 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        result, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed, info = " +
-                        str(prob.driver.pyopt_solution.optInform))
+        self.assertFalse(failed, "Optimization failed, info = " +
+                         str(prob.driver.pyopt_solution.optInform))
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['z'][1], 0.0, 1e-3)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -245,7 +245,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.setup(check=False, mode='fwd')
         prob.set_solver_print(level=0)
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed.")
 
@@ -283,7 +283,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='auto')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed.")
 
@@ -314,7 +314,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed.")
 
@@ -348,7 +348,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.set_val('x', 50.)
         prob.set_val('y', 50.)
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -375,7 +375,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -402,7 +402,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -432,7 +432,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -464,7 +464,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -495,7 +495,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -687,7 +687,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -716,7 +716,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -746,7 +746,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -774,7 +774,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -802,7 +802,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -830,7 +830,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -858,7 +858,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -886,7 +886,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -916,7 +916,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -945,7 +945,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -974,7 +974,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1002,7 +1002,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1030,7 +1030,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1058,7 +1058,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1081,7 +1081,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1174,7 +1174,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1203,7 +1203,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver(optimizer='COBYLA', tol=1e-9, disp=False)
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1227,7 +1227,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1457,7 +1457,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1489,7 +1489,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
@@ -1521,9 +1521,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed.")
+        self.assertTrue(result.success, "Optimization failed.")
 
         self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('f_xy', [0])" in output)
@@ -1550,9 +1550,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed.")
+        self.assertTrue(result.success, "Optimization failed.")
 
         self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('x', [0])" in output)
@@ -1580,9 +1580,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        failed, output = run_driver(prob)
+        result, output = run_driver(prob)
 
-        self.assertFalse(failed, "Optimization failed.")
+        self.assertTrue(result.success, "Optimization failed.")
 
         output = output.split('\n')
 
@@ -1621,7 +1621,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=False)
 
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['z'][1], 0.0, 1e-3)
@@ -1931,7 +1931,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob = om.Problem(model, driver)
         prob.setup()
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, f"Optimization failed, result = \n{prob.driver.result}")
 
@@ -1965,7 +1965,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob = om.Problem(model, driver)
         prob.setup()
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, f"Optimization failed, result = \n{prob.driver.result}")
 
@@ -2000,7 +2000,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob = om.Problem(model, driver)
         prob.setup()
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
 
         self.assertFalse(failed, f"Optimization failed, result = \n{prob.driver.result}")
 

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -23,6 +23,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning, asser
 from openmdao.utils.general_utils import run_driver
 from openmdao.utils.testing_utils import set_env_vars_context, use_tempdirs
 from openmdao.utils.mpi import MPI
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 try:
     from openmdao.parallel_api import PETScVector
@@ -227,6 +228,34 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         self.assertEqual(exception.args[0], msg)
 
+    def test_boolean_driver_return_deprecation(self):
+        # Make sure 'array' return_format works.
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('x', val=0.)
+        model.set_input_defaults('y', val=0.)
+
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_objective('f_xy')
+
+        prob.setup(check=False, mode='fwd')
+        prob.set_solver_print(level=0)
+
+        failed = prob.run_driver()
+
+        expected_warning = ('boolean evaluation of DriverResult is temporarily '
+                            'implemented to mimick the previous `failed` return '
+                            'behavior of run_driver.\nUse the `success` attribute '
+                            'of the returned DriverResult object to test for '
+                            'successful driver completion.')
+        with assert_warning(OMDeprecationWarning, expected_warning):
+            self.assertFalse(failed, "Optimization failed.")
+
     def test_compute_totals_basic_return_array(self):
         # Make sure 'array' return_format works.
 
@@ -351,7 +380,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'], 6.66666667, 1e-6)
         assert_near_equal(prob['y'], -7.3333333, 1e-6)
@@ -378,7 +407,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'], 6.66666667, 1e-6)
         assert_near_equal(prob['y'], -7.3333333, 1e-6)
@@ -405,7 +434,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'], 6.66666667, 1e-6)
         assert_near_equal(prob['y'], -7.3333333, 1e-6)
@@ -435,7 +464,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         assert_near_equal(prob['x'], 7.16667, 1e-6)
@@ -467,7 +496,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         assert_near_equal(prob['x'], 7.16667, 1e-6)
@@ -498,7 +527,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         # (Note, loose tol because of appveyor py3.4 machine.)
@@ -690,7 +719,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['y'] - prob['x'], -11.0, 1e-6)
 
@@ -719,7 +748,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
@@ -749,7 +778,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         obj = prob['o']
         assert_near_equal(obj, 20.0, 1e-6)
@@ -777,7 +806,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         obj = prob['o']
         assert_near_equal(obj, 41.5, 1e-6)
@@ -805,7 +834,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         obj = prob['o']
         assert_near_equal(obj, 41.5, 1e-6)
@@ -833,7 +862,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         obj = prob['o']
         assert_near_equal(obj, 41.5, 1e-6)
@@ -861,7 +890,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         con = prob['areas']
         assert_near_equal(con, np.array([[24.0, 21.0], [3.5, 17.5]]), 1e-6)
@@ -889,7 +918,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         obj = prob['o']
         assert_near_equal(obj, 20.0, 1e-6)
@@ -919,7 +948,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         obj = prob['o']
         assert_near_equal(obj, 20.0, 1e-6)
@@ -948,7 +977,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
@@ -977,7 +1006,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
@@ -1005,7 +1034,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
@@ -1033,7 +1062,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
@@ -1061,7 +1090,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
@@ -1084,7 +1113,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['z'][1], 0.0, 1e-3)
@@ -1177,7 +1206,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         assert_near_equal(prob['x'], 7.16667, 1e-6)
@@ -1206,7 +1235,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         assert_near_equal(prob['indep.xy'], [-1, 7.16667, -7.833334, -1], 1e-6)
@@ -1230,7 +1259,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['z'][1], 0.0, 1e-3)
@@ -1460,7 +1489,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         assert_near_equal(prob['x'], 7.16667, 1e-6)
@@ -1492,7 +1521,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         failed = not prob.run_driver().success
 
         self.assertFalse(failed, "Optimization failed, result =\n" +
-                                 str(prob.driver.result))
+                                 str(prob.driver._scipy_optimize_result))
 
         # Minimum should be at (7.166667, -7.833334)
         assert_near_equal(prob['x'], 7.16667, 1e-6)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1521,9 +1521,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        result, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed.")
+        self.assertFalse(failed, "Optimization failed.")
 
         self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('f_xy', [0])" in output)
@@ -1550,9 +1550,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='fwd')
 
-        result, output = run_driver(prob)
+        fail, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed.")
+        self.assertFalse(fail, "Optimization failed.")
 
         self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('x', [0])" in output)
@@ -1580,9 +1580,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        result, output = run_driver(prob)
+        failed, output = run_driver(prob)
 
-        self.assertTrue(result.success, "Optimization failed.")
+        self.assertFalse(False, "Optimization failed.")
 
         output = output.split('\n')
 

--- a/openmdao/recorders/tests/test_load_case.py
+++ b/openmdao/recorders/tests/test_load_case.py
@@ -280,7 +280,7 @@ class TestLoadCase(unittest.TestCase):
         model = prob.model
         model.nonlinear_solver.add_recorder(self.recorder)
 
-        fail = prob.run_driver()
+        fail = not prob.run_driver().success
         prob.cleanup()
 
         self.assertFalse(fail, 'Problem failed to converge')
@@ -323,7 +323,7 @@ class TestLoadCase(unittest.TestCase):
         prob.set_solver_print(0)
 
         prob.setup()
-        fail = prob.run_driver()
+        fail = not prob.run_driver().success
         prob.cleanup()
 
         self.assertFalse(fail, 'Problem failed to converge')

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2182,7 +2182,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.recording_options['record_desvars'] = True
         prob.add_recorder(self.recorder)
 
-        fail = prob.run_driver()
+        fail = not prob.run_driver().success
 
         prob.record('final')
         prob.cleanup()

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -565,7 +565,7 @@ def run_driver(prob):
 
     sys.stdout = strout
     try:
-        failed = prob.run_driver()
+        failed = not prob.run_driver().success
     finally:
         sys.stdout = stdout
 

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -207,7 +207,7 @@ def _make_header_table(prob):
     """
     t = datetime.datetime.now()
     time_stamp = t.strftime("%Y-%m-%d %H:%M:%S %Z")
-    runtime = prob.driver.opt_result['runtime']
+    runtime = prob.driver.opt_result.runtime
     runtime_ms = (runtime * 1000.0) % 1000.0
     runtime_formatted = \
         f"{time.strftime('%H hours %M minutes %S seconds', time.gmtime(runtime))} " \
@@ -217,12 +217,12 @@ def _make_header_table(prob):
     rows.append(['Problem:', prob._name])
     rows.append(['Script:', sys.argv[0]])
     rows.append(['Optimizer:', prob.driver._get_name()])
-    rows.append(['Number of driver iterations:', prob.driver.opt_result['iter_count']])
-    rows.append(['Number of objective calls:', prob.driver.opt_result['obj_calls']])
-    rows.append(['Number of derivative calls:', prob.driver.opt_result['deriv_calls']])
+    rows.append(['Number of driver iterations:', prob.driver.opt_result.iter_count])
+    rows.append(['Number of objective calls:', prob.driver.opt_result.obj_calls])
+    rows.append(['Number of derivative calls:', prob.driver.opt_result.deriv_calls])
     rows.append(['Execution start time:', time_stamp])
     rows.append(['Wall clock run time:', runtime_formatted])
-    rows.append(['Exit status:', prob.driver.opt_result['exit_status']])
+    rows.append(['Exit status:', prob.driver.opt_result.exit_status])
 
     return generate_table(rows, tablefmt='html')
 

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -207,7 +207,7 @@ def _make_header_table(prob):
     """
     t = datetime.datetime.now()
     time_stamp = t.strftime("%Y-%m-%d %H:%M:%S %Z")
-    runtime = prob.driver.opt_result.runtime
+    runtime = prob.driver.result.runtime
     runtime_ms = (runtime * 1000.0) % 1000.0
     runtime_formatted = \
         f"{time.strftime('%H hours %M minutes %S seconds', time.gmtime(runtime))} " \
@@ -217,12 +217,12 @@ def _make_header_table(prob):
     rows.append(['Problem:', prob._name])
     rows.append(['Script:', sys.argv[0]])
     rows.append(['Optimizer:', prob.driver._get_name()])
-    rows.append(['Number of driver iterations:', prob.driver.opt_result.iter_count])
-    rows.append(['Number of objective calls:', prob.driver.opt_result.obj_calls])
-    rows.append(['Number of derivative calls:', prob.driver.opt_result.deriv_calls])
+    rows.append(['Number of driver iterations:', prob.driver.result.iter_count])
+    rows.append(['Number of objective calls:', prob.driver.result.obj_calls])
+    rows.append(['Number of derivative calls:', prob.driver.result.deriv_calls])
     rows.append(['Execution start time:', time_stamp])
     rows.append(['Wall clock run time:', runtime_formatted])
-    rows.append(['Exit status:', prob.driver.opt_result.exit_status])
+    rows.append(['Exit status:', prob.driver.result.exit_status])
 
     return generate_table(rows, tablefmt='html')
 

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -88,7 +88,7 @@ class TestOptimizationReport(unittest.TestCase):
         Check that the data in the opt_result dict is valid for the run.
         """
         if opt_result is None:
-            opt_result = self.prob.driver.opt_result
+            opt_result = self.prob.driver.result
         if expected is None:
             expected = {}
 
@@ -249,7 +249,7 @@ class TestOptimizationReport(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
-        self.check_opt_result(prob.driver.opt_result, expected={'obj_calls': 0, 'deriv_calls': 0})
+        self.check_opt_result(prob.driver.result, expected={'obj_calls': 0, 'deriv_calls': 0})
 
         expected_warning_msg = "The optimizer report is not applicable for Driver type 'DOEDriver', " \
                                "which does not support optimization"
@@ -296,7 +296,7 @@ class TestOptimizationReport(unittest.TestCase):
         prob.run_driver()
 
         expect = {'deriv_calls': 0}
-        self.check_opt_result(prob.driver.opt_result, expected=expect)
+        self.check_opt_result(prob.driver.result, expected=expect)
         opt_report(prob)
         self.check_opt_report(prob, expected=expect)
 

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -249,7 +249,7 @@ class TestOptimizationReport(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
-        self.check_opt_result(prob.driver.result, expected={'obj_calls': 0, 'deriv_calls': 0})
+        self.check_opt_result(prob.driver.result, expected={'obj_calls': 5, 'deriv_calls': 0})
 
         expected_warning_msg = "The optimizer report is not applicable for Driver type 'DOEDriver', " \
                                "which does not support optimization"


### PR DESCRIPTION
Inidividual driver .run() methods should still return fail, this minimizes breaking backwards compatibility.
Drivers may now override _update_results to populate driver results with additional data.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
