### PR TITLE
Jax wrap init deprecation

### DIFF
--- a/openmdao/components/func_comp_common.py
+++ b/openmdao/components/func_comp_common.py
@@ -18,7 +18,7 @@ try:
         from jax.extend import linear_util
     except ImportError:
         from jax import linear_util
-    from jax.api_util import argnums_partial
+    from jax.api_util import argnums_partial, debug_info as jax_debug_info
     from jax._src.api import _jvp, _vjp
     jax.config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
@@ -92,7 +92,7 @@ def jac_forward(fun, argnums, tangents):
         rows of J and the second would contain the next 4 rows of J.  If there is only 1 output
         variable, the values returned are grouped by input variable.
     """
-    f = linear_util.wrap_init(fun)
+    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jac_forward'))
     if argnums is None:
         def jacfunf(*args):
             return vmap(partial(_jvp, f, args), out_axes=(None, -1))(tangents)[1]
@@ -128,7 +128,7 @@ def jac_reverse(fun, argnums, tangents):
         implicit systems, the function inputs will contain both inputs and outputs in the context
         of OpenMDAO.
     """
-    f = linear_util.wrap_init(fun)
+    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jac_reverse'))
     if argnums is None:
         def jacfunr(*args):
             return vmap(_vjp(f, *args)[1])(tangents)
@@ -162,7 +162,7 @@ def jacvec_prod(fun, argnums, invals, tangent):
     function
         A function to compute the jacobian vector product.
     """
-    f = linear_util.wrap_init(fun)
+    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jacvec_prod'))
     if argnums is not None:
         invals = list(argnums_partial(f, argnums, invals)[1])
 

--- a/openmdao/components/func_comp_common.py
+++ b/openmdao/components/func_comp_common.py
@@ -92,7 +92,7 @@ def jac_forward(fun, argnums, tangents):
         rows of J and the second would contain the next 4 rows of J.  If there is only 1 output
         variable, the values returned are grouped by input variable.
     """
-    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jac_forward'))
+    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jac_forward', fun, argnums or tuple(), {}))
     if argnums is None:
         def jacfunf(*args):
             return vmap(partial(_jvp, f, args), out_axes=(None, -1))(tangents)[1]
@@ -128,7 +128,7 @@ def jac_reverse(fun, argnums, tangents):
         implicit systems, the function inputs will contain both inputs and outputs in the context
         of OpenMDAO.
     """
-    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jac_reverse'))
+    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jac_reverse', fun, argnums or tuple(), {}))
     if argnums is None:
         def jacfunr(*args):
             return vmap(_vjp(f, *args)[1])(tangents)
@@ -162,7 +162,7 @@ def jacvec_prod(fun, argnums, invals, tangent):
     function
         A function to compute the jacobian vector product.
     """
-    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jacvec_prod'))
+    f = linear_util.wrap_init(fun, debug_info=jax_debug_info('jacvec_prod', fun, argnums or tuple(), {}))
     if argnums is not None:
         invals = list(argnums_partial(f, argnums, invals)[1])
 


### PR DESCRIPTION
### Summary

Newer versions of jax require linear_util.wrap_init to take a non-empty instance of debug_info.  See [this issue](https://github.com/jax-ml/jax/issues/26480) for more detail.

This PR addresses a deprecation seen in OpenMDAO involving the ExplicitFuncComp and ImplicitFuncComp. While we'll be dropping these components in the future in favor of JaxExplicitComp and JaxImplicitComp, for the time being this resolves the deprecation.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
