### PR TITLE
Added ability for promotes to handle promotion in multiple subsystems in a single call.

### DIFF
--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -181,7 +181,7 @@ class ExplicitComponent(Component):
     def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
                    lower=None, upper=None, ref=1.0, ref0=0.0, res_ref=None, tags=None,
                    shape_by_conn=False, copy_shape=None, compute_shape=None,
-                   units_by_conn=None, compute_units=None, copy_units=None,
+                   units_by_conn=False, compute_units=None, copy_units=None,
                    distributed=None, primal_name=None):
         """
         Add an output variable to the component.

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -165,7 +165,11 @@ class ExplicitComponent(Component):
         if self._has_approx and self._use_derivatives:
             self._set_approx_partials_meta()
 
-    def add_output(self, name, val=1.0, ref=1.0, res_ref=None, **kwargs):
+    def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
+                   lower=None, upper=None, ref=1.0, ref0=0.0, res_ref=None, tags=None,
+                   shape_by_conn=False, copy_shape=None, compute_shape=None,
+                   units_by_conn=None, compute_units=None, copy_units=None,
+                   distributed=None, primal_name=None):
         """
         Add an output variable to the component.
 
@@ -177,15 +181,60 @@ class ExplicitComponent(Component):
             Name of the variable in this component's namespace.
         val : float or list or tuple or ndarray
             The initial value of the variable being added in user-defined units. Default is 1.0.
+        shape : int or tuple or list or None
+            Shape of this variable, only required if val is not an array.
+            Default is None.
+        units : str or None
+            Units in which the output variables will be provided to the component during execution.
+            Default is None, which means it has no units.
+        res_units : str or None
+            Units in which the residuals of this output will be given to the user when requested.
+            Default is None, which means it has no units.
+        desc : str
+            Description of the variable.
+        lower : float or list or tuple or ndarray or None
+            Lower bound(s) in user-defined units. It can be (1) a float, (2) an array_like
+            consistent with the shape arg (if given), or (3) an array_like matching the shape of
+            val, if val is array_like. A value of None means this output has no lower bound.
+            Default is None.
+        upper : float or list or tuple or ndarray or None
+            Upper bound(s) in user-defined units. It can be (1) a float, (2) an array_like
+            consistent with the shape arg (if given), or (3) an array_like matching the shape of
+            val, if val is array_like. A value of None means this output has no upper bound.
+            Default is None.
         ref : float
             Scaling parameter. The value in the user-defined units of this output variable when
             the scaled value is 1. Default is 1.
+        ref0 : float
+            Scaling parameter. The value in the user-defined units of this output variable when
+            the scaled value is 0. Default is 0.
         res_ref : float
             Scaling parameter. The value in the user-defined res_units of this output's residual
             when the scaled value is 1. Default is None, which means residual scaling matches
             output scaling.
-        **kwargs : dict
-            Additional named arguments passed to the add_output method of Component.
+        tags : str or list of strs
+            User defined tags that can be used to filter what gets listed when calling
+            list_inputs and list_outputs and also when listing results from case recorders.
+        shape_by_conn : bool
+            If True, shape this output to match its connected input(s).
+        copy_shape : str or None
+            If a str, that str is the name of a variable. Shape this output to match that of
+            the named variable.
+        compute_shape : function or None
+            If a function, that function is called to determine the shape of this output.
+        units_by_conn : bool
+            If True, units are computed by the connected input(s).
+        compute_units : function or None
+            If a function, that function is called to determine the units of this output.
+        copy_units : str or None
+            If a str, that str is the name of a variable. Units this output to match that of
+            the named variable.
+        distributed : bool
+            If True, this variable is a distributed variable, so it can have different sizes/values
+            across MPI processes.
+        primal_name : str or None
+            Valid python name to represent the variable in compute_primal if 'name' is not a valid
+            python name.
 
         Returns
         -------
@@ -195,7 +244,15 @@ class ExplicitComponent(Component):
         if res_ref is None:
             res_ref = ref
 
-        return super().add_output(name, val=val, ref=ref, res_ref=res_ref, **kwargs)
+        return super().add_output(name, val=val, shape=shape, units=units,
+                                  res_units=res_units, desc=desc,
+                                  lower=lower, upper=upper,
+                                  ref=ref, ref0=ref0, res_ref=res_ref,
+                                  tags=tags, shape_by_conn=shape_by_conn,
+                                  copy_shape=copy_shape, compute_shape=compute_shape,
+                                  units_by_conn=units_by_conn, compute_units=compute_units,
+                                  copy_units=copy_units,
+                                  distributed=distributed, primal_name=primal_name)
 
     def _approx_subjac_keys_iter(self):
         is_output = self._outputs._contains_abs

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1827,11 +1827,12 @@ class Group(System):
                     # accurately reflect this proc's var size instead of one from some other proc.
                     allprocs_abs2meta[io].update(old_abs2meta[io])
 
-        invalid_proms = set.intersection(*not_found_all_subsys.values())
-        if invalid_proms:
-            raise RuntimeError('The following variables promoted promoted '
-                                f"in group '{self.pathname}' were not found:"
-                                '\n' + '\n'.join(sorted(invalid_proms)))
+        if not_found_all_subsys:
+            invalid_proms = set.intersection(*not_found_all_subsys.values())
+            if invalid_proms:
+                raise RuntimeError('The following variables promoted in group '
+                                    f"'{self.pathname}' were not found:"
+                                    '\n  - ' + '\n  - '.join(sorted(invalid_proms)))
 
         self._var_allprocs_abs2meta = allprocs_abs2meta
 
@@ -3483,7 +3484,7 @@ class Group(System):
 
                 try:
                     prominfo = _PromotesInfo(src_indices, flat_src_indices, src_shape,
-                                             promoted_from=subsys.pathname, as_func=name_func)
+                                             promoted_from=subsys.pathname, name_func=name_func)
                 except Exception as err:
                     lst = []
                     if any is not None:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2780,9 +2780,14 @@ class System(object, metaclass=SystemMetaclass):
             Determine the mapping of promoted names to the parent scope for a promotion type.
 
             This is called once for promotes or separately for promotes_inputs and promotes_outputs.
+
+            Returns
+            -------
+            set
+                A set of the promoted names in the system for which matches were not found.
             """
             if not to_match:
-                return
+                return set()
 
             # always add '*' so we won't report if it matches nothing (in the case where the
             # system has no variables of that io type)
@@ -2854,7 +2859,7 @@ class System(object, metaclass=SystemMetaclass):
                 raise RuntimeError("%s: 'promotes' cannot be used at the same time as "
                                    "'promotes_inputs' or 'promotes_outputs'." % self.msginfo)
             not_found = resolve(self._var_promotes['input'], ('input',), maps, self._resolver, name_func)
-            not_found.add(resolve(self._var_promotes['output'], ('output',), maps, self._resolver, name_func))
+            not_found.update(resolve(self._var_promotes['output'], ('output',), maps, self._resolver, name_func))
         else:
             not_found = resolve(self._var_promotes['any'], ('input', 'output'), maps, self._resolver, name_func)
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2405,6 +2405,31 @@ class TestGroupPromotes(unittest.TestCase):
         assert_near_equal(p.get_val('a3'), 3.)
         assert_near_equal(p.get_val('a4'), 2.5)
 
+    def test_promotes_if_present(self):
+        p = om.Problem()
+
+        p.model.add_subsystem('c1', om.ExecComp('a1=b+c'))
+        p.model.add_subsystem('c2', om.ExecComp('a2=b*c'))
+        p.model.add_subsystem('c3', om.ExecComp('a3=k-j'))
+        p.model.add_subsystem('c4', om.ExecComp('a4=k/j'))
+
+        p.model.promotes('c*', any=['a*', 'b', 'c', 'k', 'j', 'w'])
+
+        p.setup()
+
+        p.set_val('b', 5.0)
+        p.set_val('c', 2.0)
+
+        p.set_val('k', 10.0)
+        p.set_val('j', 5.0)
+
+        p.run_model()
+
+        assert_near_equal(p.get_val('a1'), 7.)
+        assert_near_equal(p.get_val('a2'), 10.)
+        assert_near_equal(p.get_val('a3'), 5.)
+        assert_near_equal(p.get_val('a4'), 2.)
+
     def test_promotes_multiple_subsys_with_aliases(self):
         p = om.Problem()
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2499,8 +2499,6 @@ class TestGroupPromotes(unittest.TestCase):
         assert_near_equal(p.get_val('a4'), 2.)
 
 
-
-
 class MyComp(om.ExplicitComponent):
     def __init__(self, input_shape, src_indices=None, flat_src_indices=False):
         super().__init__()

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -10,6 +10,7 @@ from openmdao.solvers.linear.direct import format_singular_error
 from openmdao.matrices.dense_matrix import DenseMatrix
 from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
 from openmdao.utils.om_warnings import issue_warning, SolverWarning
+from openmdao.utils.mpi import FakeComm
 
 try:
     from petsc4py import PETSc
@@ -19,7 +20,7 @@ try:
     from mpi4py import MPI
     DEFAULT_COMM = MPI.COMM_WORLD
 except ImportError:
-    DEFAULT_COMM = None
+    DEFAULT_COMM = FakeComm()
 
 PC_SERIAL_TYPES = [
     "superlu",


### PR DESCRIPTION
### Summary

This is an experimental feature to add the ability for promotes to take a Sequence of subsystem names with glob patterns.
It also supports a name function that is a bit more flexible than the existing ('var_name', 'promote_as') tuple method.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
