### PR TITLE
  Replace INF_BOUND sentinel with None/np.inf for infinite bounds

### DIFF
--- a/openmdao/core/constants.py
+++ b/openmdao/core/constants.py
@@ -7,6 +7,8 @@ from enum import IntEnum
 import numpy as np
 
 
+# Retained for backwards compatibility. Infinite bounds are now stored as None or np.inf
+# internally. Do not use this constant for new code.
 INF_BOUND = 1.0E30
 
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -14,7 +14,7 @@ import scipy.sparse as sp
 from openmdao.drivers.autoscalers.autoscaler import Autoscaler
 from openmdao.core.group import Group
 from openmdao.core.total_jac import _TotalJacInfo
-from openmdao.core.constants import INT_DTYPE, INF_BOUND, _SetupStatus
+from openmdao.core.constants import INT_DTYPE, _SetupStatus
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.record_util import create_local_meta, check_path, has_match
@@ -274,6 +274,8 @@ class Driver(object, metaclass=DriverMetaclass):
         The autoscaler instance used to scale/unscale values for the optimizer.
     """
 
+    _inf_bound = np.inf
+
     def __init__(self, **kwargs):
         """
         Initialize the driver.
@@ -380,6 +382,30 @@ class Driver(object, metaclass=DriverMetaclass):
         if self._problem is None:
             return None
         return f"{self._problem()._get_inst_id()}.driver"
+
+    def _to_driver_bound(self, arr):
+        """
+        Convert a bound array from internal np.inf/-np.inf sentinels to the driver's preferred form.
+
+        Replaces -np.inf with -self._inf_bound and np.inf with self._inf_bound.
+
+        Parameters
+        ----------
+        arr : ndarray or None
+            Bound array from the autoscaler, potentially containing ±np.inf.
+
+        Returns
+        -------
+        ndarray or None
+            Bound array with ±np.inf replaced by ±self._inf_bound. Returns arr unchanged if
+            arr is None or _inf_bound is np.inf.
+        """
+        if arr is None or self._inf_bound is np.inf:
+            return arr
+        result = np.array(arr, dtype=float)
+        result[np.isposinf(result)] = self._inf_bound
+        result[np.isneginf(result)] = -self._inf_bound
+        return result
 
     @property
     def msginfo(self):
@@ -1279,12 +1305,26 @@ class Driver(object, metaclass=DriverMetaclass):
                 if meta['equals'] is not None:
                     con_val -= meta['equals']
                 else:
-                    lower_viol_idxs = np.where(con_val < meta['lower'])[0]
-                    upper_viol_idxs = np.where(con_val > meta['upper'])[0]
-                    non_viol_idxs = np.where((con_val >= meta['lower'])
-                                             & (con_val <= meta['upper']))[0]
-                    con_val[lower_viol_idxs] -= meta['lower']
-                    con_val[upper_viol_idxs] -=  meta['upper']
+                    lower = meta['lower']
+                    upper = meta['upper']
+                    has_lower = lower is not None and not np.all(np.isneginf(np.atleast_1d(lower)))
+                    has_upper = upper is not None and not np.all(np.isposinf(np.atleast_1d(upper)))
+                    if has_lower:
+                        lower_viol_idxs = np.where(con_val < lower)[0]
+                    else:
+                        lower_viol_idxs = np.empty(0, dtype=int)
+                    if has_upper:
+                        upper_viol_idxs = np.where(con_val > upper)[0]
+                    else:
+                        upper_viol_idxs = np.empty(0, dtype=int)
+                    viol_idxs = np.union1d(lower_viol_idxs, upper_viol_idxs)
+                    non_viol_idxs = np.setdiff1d(np.arange(len(con_val)), viol_idxs)
+                    if has_lower:
+                        con_val[lower_viol_idxs] -= lower if np.isscalar(lower) \
+                            else np.asarray(lower)[lower_viol_idxs]
+                    if has_upper:
+                        con_val[upper_viol_idxs] -= upper if np.isscalar(upper) \
+                            else np.asarray(upper)[upper_viol_idxs]
                     con_val[non_viol_idxs] = 0.0
 
             con_dict[name] = con_vec[name].copy()
@@ -1904,8 +1944,8 @@ class Driver(object, metaclass=DriverMetaclass):
         dv_vals = self.get_design_var_values(driver_scaling=True)
         con_vals = self.get_constraint_values(driver_scaling=True)
 
-        lower_dv, upper_dv, _ = self._autoscaler.get_bounds_scaling('design_var')
-        lower_con, upper_con, _ = self._autoscaler.get_bounds_scaling('constraint')
+        dv_bounds = self._autoscaler.get_bounds_scaling('design_var')
+        con_bounds = self._autoscaler.get_bounds_scaling('constraint')
 
         for constraint, con_options in constraints.items():
             constraint_value = con_vals[constraint]
@@ -1917,19 +1957,19 @@ class Driver(object, metaclass=DriverMetaclass):
                                            'active_bounds': np.zeros(con_size, dtype=int)}
             else:
                 # Inequality constraint, determine active indices and bounds
-                constraint_upper = upper_con[constraint]
-                constraint_lower = lower_con[constraint]
+                constraint_upper = con_bounds[constraint].upper
+                constraint_lower = con_bounds[constraint].lower
 
-                if np.all(np.isinf(constraint_upper)):
-                    upper_idxs = np.empty()
+                if constraint_upper is None:
+                    upper_idxs = np.empty(0, dtype=int)
                 else:
                     upper_mask = np.logical_or(constraint_value > constraint_upper,
                                                np.isclose(constraint_value, constraint_upper,
                                                           atol=feas_atol, rtol=feas_rtol))
                     upper_idxs = np.where(upper_mask)[0]
 
-                if np.all(np.isinf(constraint_lower)):
-                    lower_idxs = np.empty()
+                if constraint_lower is None:
+                    lower_idxs = np.empty(0, dtype=int)
                 else:
                     lower_mask = np.logical_or(constraint_value < constraint_lower,
                                                np.isclose(constraint_value, constraint_lower,
@@ -1946,21 +1986,27 @@ class Driver(object, metaclass=DriverMetaclass):
             des_var_value = dv_vals[des_var]
             des_var_size = des_var_options['size']
 
-            des_var_upper = upper_dv[des_var]
-            des_var_lower = lower_dv[des_var]
+            des_var_upper = dv_bounds[des_var].upper
+            des_var_lower = dv_bounds[des_var].lower
 
             if assume_dvs_active:
                 active_dvs[des_var] = {'indices': np.arange(des_var_size, dtype=int),
                                        'active_bounds': np.zeros(des_var_size, dtype=int)}
             else:
-                upper_mask = np.logical_or(des_var_value > des_var_upper,
-                                           np.isclose(des_var_value, des_var_upper,
-                                                      atol=feas_atol, rtol=feas_rtol))
-                upper_idxs = np.where(upper_mask)[0]
-                lower_mask = np.logical_or(des_var_value < des_var_lower,
-                                           np.isclose(des_var_value, des_var_lower,
-                                                      atol=feas_atol, rtol=feas_rtol))
-                lower_idxs = np.where(lower_mask)[0]
+                if des_var_upper is None:
+                    upper_idxs = np.empty(0, dtype=int)
+                else:
+                    upper_mask = np.logical_or(des_var_value > des_var_upper,
+                                               np.isclose(des_var_value, des_var_upper,
+                                                          atol=feas_atol, rtol=feas_rtol))
+                    upper_idxs = np.where(upper_mask)[0]
+                if des_var_lower is None:
+                    lower_idxs = np.empty(0, dtype=int)
+                else:
+                    lower_mask = np.logical_or(des_var_value < des_var_lower,
+                                               np.isclose(des_var_value, des_var_lower,
+                                                          atol=feas_atol, rtol=feas_rtol))
+                    lower_idxs = np.where(lower_mask)[0]
 
                 active_idxs = sorted(np.concatenate((upper_idxs, lower_idxs)))
                 active_bounds = [1 if idx in upper_idxs else -1 for idx in active_idxs]
@@ -2379,38 +2425,35 @@ class Driver(object, metaclass=DriverMetaclass):
         if method == 'lm':
             bounds = (-np.inf, np.inf)
 
-            if any(meta['lower'] > -1.0E16 or
-                   meta['upper'] < 1.0E16 for meta in self._designvars.values()):
+            if any((meta['lower'] is not None and np.any(np.atleast_1d(meta['lower']) > -1.0E16)) or
+                   (meta['upper'] is not None and np.any(np.atleast_1d(meta['upper']) < 1.0E16))
+                   for meta in self._designvars.values()):
                 issue_warning("find_feasible method is 'lm' which ignores bounds "
                               "but one or more design variables have bounds.")
         else:
             i = 0
             bounds = []
 
-            lower_dv, upper_dv, _ = self._autoscaler.get_bounds_scaling('design_var')
+            dv_bounds = self._autoscaler.get_bounds_scaling('design_var')
 
             for name, val in desvar_vals.items():
                 meta = self._designvars[name]
                 size = meta['global_size'] if meta['distributed'] else meta['size']
 
-                meta_low = lower_dv[name]
-                meta_high = upper_dv[name]
+                meta_low = dv_bounds[name].lower
+                meta_high = dv_bounds[name].upper
                 for j in range(size):
-                    p_low = meta_low[j]
-                    p_high = meta_high[j]
-
-                    p_low = -np.inf if p_low <= -INF_BOUND else p_low
-                    p_high = np.inf if p_high >= INF_BOUND else p_high
+                    p_low = None if meta_low is None else meta_low[j]
+                    p_high = None if meta_high is None else meta_high[j]
 
                     # If lower and upper are equal at any indices, add some slack
-                    equal_idxs = np.where(np.atleast_1d(np.abs(p_high - p_low)) < 1.0E-16)[0]
-
-                    # Releive bounds if they are pinched
-                    # TODO: Handle this more generically in all drivers
-                    if np.isscalar(p_high):
-                        p_high += 1.0E-16
-                    else:
-                        p_high[equal_idxs] += 1.0E-16
+                    if p_low is not None and p_high is not None:
+                        equal_idxs = np.where(
+                            np.atleast_1d(np.abs(p_high - p_low)) < 1.0E-16)[0]
+                        if np.isscalar(p_high):
+                            p_high += 1.0E-16
+                        else:
+                            p_high[equal_idxs] += 1.0E-16
 
                     bounds.append((p_low, p_high))
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1968,13 +1968,13 @@ class Problem(object, metaclass=ProblemMetaclass):
         desvar_opts = [opt for opt in desvar_opts if _find_dict_meta(desvars, opt)]
     
         if ('lower' in desvar_opts or 'upper' in desvar_opts) and driver_scaling:
-            lower, upper, _ = self.driver._autoscaler.get_bounds_scaling('design_var')
+            dv_bounds = self.driver._autoscaler.get_bounds_scaling('design_var')
             for name in desvars:
                 if not desvars[name]['discrete']:
                     if 'lower' in desvar_opts:
-                        desvars[name]['lower'] = lower[name]
+                        desvars[name]['lower'] = dv_bounds[name].lower
                     if 'upper' in desvar_opts:
-                        desvars[name]['upper'] = upper[name]
+                        desvars[name]['upper'] = dv_bounds[name].upper
 
         # include units in our outputs if any constraints have units that are not None
         has_units = any(dvmeta.get('units', None) is not None for dvname, dvmeta in desvars.items())
@@ -2016,14 +2016,14 @@ class Problem(object, metaclass=ProblemMetaclass):
             cons_opts.append('units')
         if (('lower' in cons_opts or 'upper' in cons_opts or 'equals' in cons_opts)
             and driver_scaling):
-            lower, upper, equals = self.driver._autoscaler.get_bounds_scaling('constraint')
+            con_bounds = self.driver._autoscaler.get_bounds_scaling('constraint')
             for name in cons:
                 if 'lower' in cons_opts:
-                    cons[name]['lower'] = lower[name]
+                    cons[name]['lower'] = con_bounds[name].lower
                 if 'upper' in cons_opts:
-                    cons[name]['upper'] = upper[name]
+                    cons[name]['upper'] = con_bounds[name].upper
                 if 'equals' in cons_opts:
-                    cons[name]['equals'] = equals[name]
+                    cons[name]['equals'] = con_bounds[name].equals
         col_names = default_col_names + def_cons_opts + cons_opts
         if 'units' in col_names and driver_scaling:
             for c in cons:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -17,7 +17,7 @@ from numbers import Integral
 import numpy as np
 
 from openmdao.core.constants import _DEFAULT_COLORING_DIR, _DEFAULT_OUT_STREAM, \
-    _UNDEFINED, INT_DTYPE, INF_BOUND, _SetupStatus
+    _UNDEFINED, INT_DTYPE, _SetupStatus
 from openmdao.jacobians.dictionary_jacobian import Jacobian
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.vectors.vector import _full_slice
@@ -1015,17 +1015,11 @@ class System(object, metaclass=SystemMetaclass):
             if is_undefined(upper):
                 upper = None
 
-            if lower is None:
-                # if not set, set lower to -INF_BOUND and don't apply adder/scaler
-                lower = -INF_BOUND
-            else:
+            if lower is not None:
                 # Convert lower to ndarray/float as necessary
                 lower = format_as_float_or_array('lower', lower, flatten=True)
 
-            if upper is None:
-                # if not set, set upper to INF_BOUND and don't apply adder/scaler
-                upper = INF_BOUND
-            else:
+            if upper is not None:
                 # Convert upper to ndarray/float as necessary
                 upper = format_as_float_or_array('upper', upper, flatten=True)
             
@@ -1178,9 +1172,7 @@ class System(object, metaclass=SystemMetaclass):
 
             # Convert lower to ndarray/float as necessary
             try:
-                if lower is None:
-                    lower = -INF_BOUND
-                else:
+                if lower is not None:
                     lower = format_as_float_or_array('lower', lower, flatten=True)
             except (TypeError, ValueError):
                 raise TypeError("Argument 'lower' can not be a string ('{}' given). You can not "
@@ -1189,9 +1181,7 @@ class System(object, metaclass=SystemMetaclass):
 
             # Convert upper to ndarray/float as necessary
             try:
-                if upper is None:
-                    upper = INF_BOUND
-                else:
+                if upper is not None:
                     upper = format_as_float_or_array('upper', upper, flatten=True)
             except (TypeError, ValueError):
                 raise TypeError("Argument 'upper' can not be a string ('{}' given). You can not "
@@ -3306,14 +3296,10 @@ class System(object, metaclass=SystemMetaclass):
         ref = format_as_float_or_array('ref', ref, val_if_none=None, flatten=True)
         ref0 = format_as_float_or_array('ref0', ref0, val_if_none=None, flatten=True)
 
-        if lower is None:
-            lower = -INF_BOUND
-        else:
+        if lower is not None:
             lower = format_as_float_or_array('lower', lower, flatten=True)
-        
-        if upper is None:
-            upper = INF_BOUND
-        else:
+
+        if upper is not None:
             upper = format_as_float_or_array('upper', upper, flatten=True)
 
         if self._static_mode:
@@ -3477,10 +3463,7 @@ class System(object, metaclass=SystemMetaclass):
 
             # Convert lower to ndarray/float as necessary
             try:
-                if lower is None:
-                    # don't apply adder/scaler if lower not set
-                    lower = -INF_BOUND
-                else:
+                if lower is not None:
                     lower = format_as_float_or_array('lower', lower, flatten=True)
             except (TypeError, ValueError):
                 raise TypeError("Argument 'lower' can not be a string ('{}' given). You can not "
@@ -3489,10 +3472,7 @@ class System(object, metaclass=SystemMetaclass):
 
             # Convert upper to ndarray/float as necessary
             try:
-                if upper is None:
-                    # don't apply adder/scaler if upper not set
-                    upper = INF_BOUND
-                else:
+                if upper is not None:
                     upper = format_as_float_or_array('upper', upper, flatten=True)
             except (TypeError, ValueError):
                 raise TypeError("Argument 'upper' can not be a string ('{}' given). You can not "

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -444,7 +444,7 @@ class TestDesvarOnModel(unittest.TestCase):
 
     def test_desvar_inf_bounds(self):
 
-        # make sure no overflow when there is no specified upper/lower bound and significatn scaling
+        # make sure unbounded variables have None bounds (not overflow-prone large floats)
 
         prob = om.Problem()
 
@@ -461,15 +461,15 @@ class TestDesvarOnModel(unittest.TestCase):
 
         des_vars = prob.model.get_design_vars()
 
-        self.assertFalse(np.isinf(des_vars['x']['upper']))
-        self.assertFalse(np.isinf(-des_vars['x']['lower']))
+        self.assertIsNone(des_vars['x']['upper'])
+        self.assertIsNone(des_vars['x']['lower'])
 
         responses = prob.model.get_responses()
 
-        self.assertFalse(np.isinf(responses['con_cmp1.con1']['upper']))
-        self.assertFalse(np.isinf(responses['con_cmp2.con2']['upper']))
-        self.assertFalse(np.isinf(-responses['con_cmp1.con1']['lower']))
-        self.assertFalse(np.isinf(-responses['con_cmp2.con2']['lower']))
+        self.assertIsNone(responses['con_cmp1.con1']['upper'])
+        self.assertIsNone(responses['con_cmp2.con2']['upper'])
+        self.assertIsNone(responses['con_cmp1.con1']['lower'])
+        self.assertIsNone(responses['con_cmp2.con2']['lower'])
 
     def test_desvar_invalid_name(self):
 

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -186,7 +186,7 @@ class TestDriver(unittest.TestCase):
 
     def test_vector_bounds_inf(self):
 
-        # make sure no overflow when there is no specified upper/lower bound and significatn scaling
+        # make sure unbounded variables have None bounds (not overflow-prone large floats)
         prob = om.Problem()
         model = prob.model
 
@@ -202,13 +202,13 @@ class TestDriver(unittest.TestCase):
 
         desvars = model.get_design_vars()
 
-        self.assertFalse(np.any(np.isinf(desvars['px.x']['upper'])))
-        self.assertFalse(np.any(np.isinf(-desvars['px.x']['lower'])))
+        self.assertIsNone(desvars['px.x']['upper'])
+        self.assertIsNone(desvars['px.x']['lower'])
 
         responses = prob.model.get_responses()
 
-        self.assertFalse(np.any(np.isinf(responses['comp.y2']['upper'])))
-        self.assertFalse(np.any(np.isinf(-responses['comp.y2']['lower'])))
+        self.assertIsNone(responses['comp.y2']['upper'])
+        self.assertIsNone(responses['comp.y2']['lower'])
 
     def test_vector_scaled_derivs_diff_sizes(self):
 

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -1492,18 +1492,18 @@ class TestScalingOverhaul(unittest.TestCase):
         assert_near_equal(driver.param_vals['p.x1_s_u'], 1.0)
         assert_near_equal(driver.param_vals['p.x1_s_s'], 1.0/7.0)
 
-        _, scaled_dv_ub, _ = prob.driver._autoscaler.get_bounds_scaling('design_var')
-        _, scaled_con_ub, _ = prob.driver._autoscaler.get_bounds_scaling('constraint')
+        dv_scaling = prob.driver._autoscaler.get_bounds_scaling('design_var')
+        con_scaling = prob.driver._autoscaler.get_bounds_scaling('constraint')
 
         assert_near_equal(driver.param_meta['p.x1_u_u']['upper'], 11.0)
-        assert_near_equal(scaled_dv_ub['p.x1_u_s'], 11.0/7.0)
+        assert_near_equal(dv_scaling['p.x1_u_s'].upper, 11.0/7.0)
         assert_near_equal(driver.param_meta['p.x1_s_u']['upper'], 11.0)
-        assert_near_equal(scaled_dv_ub['p.x1_s_s'], 11.0/7.0)
+        assert_near_equal(dv_scaling['p.x1_s_s'].upper, 11.0/7.0)
 
         assert_near_equal(driver.con_meta['p.x1_u_u']['upper'], 3.3)
-        assert_near_equal(scaled_con_ub['p.x1_u_s'], 3.3/13.0)
+        assert_near_equal(con_scaling['p.x1_u_s'].upper, 3.3/13.0)
         assert_near_equal(driver.con_meta['p.x1_s_u']['upper'], 3.3)
-        assert_near_equal(scaled_con_ub['p.x1_s_s'], 3.3/13.0)
+        assert_near_equal(con_scaling['p.x1_s_s'].upper, 3.3/13.0)
 
         assert_near_equal(driver.con_vals['p.x1_u_u'], 1.0)
         assert_near_equal(driver.con_vals['p.x1_u_s'], 1.0/13.0)

--- a/openmdao/drivers/autoscalers/autoscaler.py
+++ b/openmdao/drivers/autoscalers/autoscaler.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from openmdao.drivers.autoscalers.autoscaler_base import AutoscalerBase
-from openmdao.core.constants import INF_BOUND
+from openmdao.vectors.bound_map import BoundMap
 from openmdao.vectors.optimizer_vector import OptimizerVector
 
 if TYPE_CHECKING:
@@ -55,14 +55,10 @@ class Autoscaler(AutoscalerBase):
                     or (scaler is not None) \
                     or (adder is not None)
 
-        # Compute and cache scaled bounds vectors for design vars and constraints
-        self._scaled_lower = {}
-        self._scaled_upper = {}
-        self._scaled_equals = {}
+        # Compute and cache scaled bounds dicts for design vars and constraints
+        self._scaled_bounds = {}
         for voi_type in ['design_var', 'constraint']:
-            self._scaled_lower[voi_type], \
-                self._scaled_upper[voi_type], \
-                self._scaled_equals[voi_type] = self._compute_scaled_bounds(voi_type)
+            self._scaled_bounds[voi_type] = self._compute_scaled_bounds(voi_type)
 
     @property
     def has_scaling(self) -> bool:
@@ -136,24 +132,21 @@ class Autoscaler(AutoscalerBase):
         ndarray
             Scaled bound array of length `size`.
         """
+        if val is None:
+            return None
+
         if np.isscalar(val):
             val_arr = np.full(size, val, dtype=float)
         else:
-            if val is None:
-                if is_lower:
-                    val = -INF_BOUND
-                else:
-                    val = INF_BOUND
-
             val_arr = np.asarray(val, dtype=float)
-                
+
             if val_arr.size != size:
                 val_arr = np.broadcast_to(val_arr, (size,)).copy()
             else:
                 val_arr = val_arr.copy()
 
         # Identify unbounded (infinite) elements before scaling
-        inf_mask = (val_arr <= -INF_BOUND) if is_lower else (val_arr >= INF_BOUND)
+        inf_mask = np.isneginf(val_arr) if is_lower else np.isposinf(val_arr)
 
         if not inf_mask.all():
             finite = ~inf_mask
@@ -162,8 +155,8 @@ class Autoscaler(AutoscalerBase):
             if scaler is not None:
                 val_arr[finite] *= scaler if np.isscalar(scaler) else np.asarray(scaler)[finite]
 
-        # Restore sentinel for unbounded elements (scaling may have perturbed them)
-        val_arr[inf_mask] = -INF_BOUND if is_lower else INF_BOUND
+        # Restore inf for unbounded elements (scaling may have perturbed them)
+        val_arr[inf_mask] = -np.inf if is_lower else np.inf
 
         val_arr = val_arr.ravel()
 
@@ -171,7 +164,7 @@ class Autoscaler(AutoscalerBase):
 
     def _compute_scaled_bounds(self, voi_type):
         """
-        Compute scaled bounds OptimizerVectors for design variables or constraints.
+        Compute a BoundMap of scaled bounds for design variables or constraints.
 
         Called once during setup() to build and cache scaled bounds. Bounds are read
         from metadata in physical (model) units and transformed to driver (optimizer)
@@ -184,70 +177,43 @@ class Autoscaler(AutoscalerBase):
 
         Returns
         -------
-        lower : OptimizerVector
-            Scaled lower bounds. Unbounded entries contain -INF_BOUND.
-        upper : OptimizerVector
-            Scaled upper bounds. Unbounded entries contain INF_BOUND.
-        equals : OptimizerVector or None
-            Scaled equality values. Non-equality constraint entries contain np.nan.
-            None when voi_type='design_var'.
+        BoundMap
+            Scaled bounds. For each variable, .lower/.upper are None if entirely unbounded,
+            and .equals is None for inequality constraints or design variables.
         """
-        vecmeta = {}
-        total_size = 0
+        bounds = BoundMap()
 
         for name, meta in self._var_meta[voi_type].items():
             if meta.get('discrete', False):
                 continue
             size = meta.get('global_size', meta.get('size', 0)) \
                 if meta.get('distributed', False) else meta.get('size', 0)
-            vecmeta[name] = {
-                'slice': slice(total_size, total_size + size),
-                'size': size,
-            }
-            total_size += size
-
-        lower_data = np.empty(total_size)
-        upper_data = np.empty(total_size)
-        equals_data = np.full(total_size, np.nan) if voi_type == 'constraint' else None
-
-        for name, vmeta in vecmeta.items():
-            meta = self._var_meta[voi_type][name]
-            if meta.get('discrete', False):
-                continue
-            size = vmeta['size']
-            s = vmeta['slice']
             adder = meta['total_adder']
             scaler = meta['total_scaler']
 
-            lower_data[s] = self._scale_bound(
-                meta.get('lower', -INF_BOUND), adder, scaler, size, is_lower=True)
-            upper_data[s] = self._scale_bound(
-                meta.get('upper', INF_BOUND), adder, scaler, size, is_lower=False)
+            eq = meta.get('equals') if voi_type == 'constraint' else None
+            bounds.set(
+                name,
+                lower=self._scale_bound(meta.get('lower', None), adder, scaler, size,
+                                        is_lower=True),
+                upper=self._scale_bound(meta.get('upper', None), adder, scaler, size,
+                                        is_lower=False),
+                equals=self._scale_bound(eq, adder, scaler, size, is_lower=False)
+                       if eq is not None else None,
+                size=size,
+            )
 
-            if voi_type == 'constraint':
-                eq = meta.get('equals')
-                if eq is not None:
-                    equals_data[s] = self._scale_bound(
-                        eq, adder, scaler, size, is_lower=False)
-
-        lower_vec = OptimizerVector(voi_type, lower_data, vecmeta)
-        upper_vec = OptimizerVector(voi_type, upper_data, vecmeta)
-        equals_vec = OptimizerVector(voi_type, equals_data, vecmeta) \
-            if voi_type == 'constraint' else None
-
-        return lower_vec, upper_vec, equals_vec
+        return bounds
 
     def get_bounds_scaling(self, voi_type):
         """
-        Return pre-computed scaled bounds vectors for the given variable type.
+        Return the pre-computed BoundMap for the given variable type.
 
         Returns bounds cached during setup() in driver (optimizer) units. The original
         metadata bounds remain in physical (model) units and are not modified.
 
-        Infinite bounds (abs value >= INF_BOUND in model space) are returned as ±INF_BOUND.
-
         If scalers change after setup (e.g. in an adaptive autoscaler subclass), call
-        _compute_scaled_bounds() again for each affected voi_type to refresh the cache.
+        _compute_scaled_bounds() again for the affected voi_type to refresh the cache.
 
         Parameters
         ----------
@@ -256,17 +222,12 @@ class Autoscaler(AutoscalerBase):
 
         Returns
         -------
-        lower : OptimizerVector
-            Scaled lower bounds. Unbounded entries contain -INF_BOUND.
-        upper : OptimizerVector
-            Scaled upper bounds. Unbounded entries contain INF_BOUND.
-        equals : OptimizerVector or None
-            Scaled equality values. Non-equality constraint entries contain np.nan as
-            a sentinel. None when voi_type='design_var'.
+        BoundMap
+            Scaled bounds. Access per-variable bounds via bounds[name].lower,
+            bounds[name].upper, and bounds[name].equals. Entirely-unbounded
+            directions return None.
         """
-        return (self._scaled_lower[voi_type],
-                self._scaled_upper[voi_type],
-                self._scaled_equals[voi_type])
+        return self._scaled_bounds[voi_type]
 
     def _apply_vec_unscaling(self, vec: 'OptimizerVector'):
         """

--- a/openmdao/drivers/autoscalers/autoscaler_base.py
+++ b/openmdao/drivers/autoscalers/autoscaler_base.py
@@ -38,7 +38,7 @@ class AutoscalerBase:
     setup(driver)
         Initialize the autoscaler with driver metadata.
         Called once at the start of the driver.run method.
-    
+
     setup_requires_run_model()
         Return True if setup of the autoscaler requires the
         model to be in an executed state.
@@ -50,11 +50,11 @@ class AutoscalerBase:
     apply_design_var_unscaling(vec)
         Unscale the design variables from the optimizer space to the model space.
         Does not modify vec; returns a new array.
-    
+
     apply_constraint_scaling(vec)
         Scale the constraints from model space to optimizer space.
         Modifies vec in-place.
-    
+
     apply_objective_scaling(vec)
         Scale the objectives from model space to optimizer space.
         Modifies vec in-place.
@@ -62,7 +62,7 @@ class AutoscalerBase:
     apply_mult_unscaling(desvar_multipliers, con_multipliers)
         Unscale Lagrange multipliers from optimizer space to physical space.
         Modifies the input dictionaries in-place.
-    
+
     apply_jac_scaling(jac_dict)
         Scale the computed total jacobian from the model/physical space to optimizer space.
 
@@ -77,14 +77,9 @@ class AutoscalerBase:
     _has_scaling : bool
         Flag indicating whether any scaling is applied to design variables, constraints,
         or objectives.
-    _scaled_lower : dict
-        Dictionary mapping VOI type to scaled lower bound arrays for design variables and
-        constraints.
-    _scaled_upper : dict
-        Dictionary mapping VOI type to scaled upper bound arrays for design variables and
-        constraints.
-    _scaled_equals : dict
-        Dictionary mapping VOI type to scaled equality constraint value arrays.
+    _scaled_bounds : dict
+        Dictionary mapping VOI type to a BoundMap of scaled bounds for design variables
+        and constraints. Access per-variable bounds via bounds[name].lower, .upper, .equals.
     _driver_ref : weakref or None
         Weak reference to the driver this autoscaler belongs to. Set during setup().
 
@@ -93,9 +88,7 @@ class AutoscalerBase:
     def __init__(self):
         self._var_meta : dict[str, dict[str, dict]] = {}
         self._has_scaling : bool = False
-        self._scaled_lower = {}
-        self._scaled_upper = {}
-        self._scaled_equals = {}
+        self._scaled_bounds = {}
         self._driver_ref = None
 
     def _get_inst_id(self):
@@ -184,15 +177,13 @@ class AutoscalerBase:
 
     def get_bounds_scaling(self, voi_type):
         """
-        Return pre-computed scaled bounds vectors for the given variable type.
+        Return the pre-computed BoundMap for the given variable type.
 
         Returns bounds cached during setup() in driver (optimizer) units. The original
         metadata bounds remain in physical (model) units and are not modified.
 
-        Infinite bounds (abs value >= INF_BOUND in model space) are returned as ±INF_BOUND.
-
         If scalers change after setup (e.g. in an adaptive autoscaler subclass), call
-        _compute_scaled_bounds() again for each affected voi_type to refresh the cache.
+        _compute_scaled_bounds() again for the affected voi_type to refresh the cache.
 
         Parameters
         ----------
@@ -201,13 +192,10 @@ class AutoscalerBase:
 
         Returns
         -------
-        lower : OptimizerVector
-            Scaled lower bounds. Unbounded entries contain -INF_BOUND.
-        upper : OptimizerVector
-            Scaled upper bounds. Unbounded entries contain INF_BOUND.
-        equals : OptimizerVector or None
-            Scaled equality values. Non-equality constraint entries contain np.nan as
-            a sentinel. None when voi_type='design_var'.
+        BoundMap
+            Scaled bounds. Access per-variable bounds via bounds[name].lower,
+            bounds[name].upper, and bounds[name].equals. Entirely-unbounded
+            directions return None.
         """
         raise NotImplementedError(f'Class {type(self).__name__} does not '
                                   'implement get_bounds_scaling.')

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -19,7 +19,6 @@ import copy
 
 import numpy as np
 
-from openmdao.core.constants import INF_BOUND
 from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.utils.concurrent_utils import concurrent_eval
 from openmdao.utils.mpi import MPI
@@ -147,22 +146,22 @@ class DifferentialEvolutionDriver(Driver):
         for name, meta in self._designvars.items():
             lower, upper = meta['lower'], meta['upper']
             for param in (lower, upper):
-                if param is None or np.all(np.abs(param) >= INF_BOUND):
+                if param is None or np.any(np.isinf(np.atleast_1d(param))):
                     msg = (f"Invalid bounds for design variable '{name}'. When using "
-                           f"{self.__class__.__name__}, values for both 'lower' and 'upper' "
-                           f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
-                           f"but they are: lower={lower}, upper={upper}.")
+                           f"{self.__class__.__name__}, finite values for both 'lower' and "
+                           f"'upper' must be specified, but they are: "
+                           f"lower={lower}, upper={upper}.")
                     raise ValueError(msg)
 
         for name, meta in self._cons.items():
             equals, lower, upper = meta['equals'], meta['lower'], meta['upper']
-            if ((equals is None or np.all(np.abs(equals) >= INF_BOUND)) and
-               (lower is None or np.all(np.abs(lower) >= INF_BOUND)) and
-               (upper is None or np.all(np.abs(upper) >= INF_BOUND))):
+            eq_unbounded = equals is None or np.all(np.isinf(np.atleast_1d(equals)))
+            lower_unbounded = lower is None or np.all(np.isinf(np.atleast_1d(lower)))
+            upper_unbounded = upper is None or np.all(np.isinf(np.atleast_1d(upper)))
+            if eq_unbounded and lower_unbounded and upper_unbounded:
                 msg = (f"Invalid bounds for constraint '{name}'. "
-                       f"When using {self.__class__.__name__}, the value for 'equals', "
-                       f"'lower' or 'upper' must be specified between +/-INF_BOUND "
-                       f"({INF_BOUND}), but they are: "
+                       f"When using {self.__class__.__name__}, a finite value for 'equals', "
+                       f"'lower' or 'upper' must be specified, but they are: "
                        f"equals={equals}, lower={lower}, upper={upper}.")
                 raise ValueError(msg)
 
@@ -413,9 +412,6 @@ class DifferentialEvolutionDriver(Driver):
             i, j = self._desvar_idx[name]
             self._set_design_var(name, x[i:j])
 
-        # a very large number, but smaller than the result of nan_to_num in Numpy
-        almost_inf = INF_BOUND
-
         # Execute the model
         with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
             self.iter_count += 1
@@ -456,14 +452,17 @@ class DifferentialEvolutionDriver(Driver):
                 constraint_violations = np.array([])
                 for name, val in self.get_constraint_values().items():
                     con = self._cons[name]
-                    # The not used fields will either None or a very large number
-                    if (con['lower'] is not None) and np.any(con['lower'] > -almost_inf):
+                    # None means unbounded; np.inf also means unbounded
+                    if con['lower'] is not None and \
+                            not np.all(np.isneginf(np.atleast_1d(con['lower']))):
                         diff = val - con['lower']
                         violation = np.array([0. if d >= 0 else abs(d) for d in diff])
-                    elif (con['upper'] is not None) and np.any(con['upper'] < almost_inf):
+                    elif con['upper'] is not None and \
+                            not np.all(np.isposinf(np.atleast_1d(con['upper']))):
                         diff = val - con['upper']
                         violation = np.array([0. if d <= 0 else abs(d) for d in diff])
-                    elif (con['equals'] is not None) and np.any(np.abs(con['equals']) < almost_inf):
+                    elif con['equals'] is not None and \
+                            not np.all(np.isinf(np.atleast_1d(con['equals']))):
                         diff = val - con['equals']
                         violation = np.absolute(diff)
                     constraint_violations = np.hstack((constraint_violations, violation))

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -26,7 +26,6 @@ import copy
 
 import numpy as np
 
-from openmdao.core.constants import INF_BOUND
 from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.utils.concurrent_utils import concurrent_eval
 from openmdao.utils.mpi import MPI
@@ -172,22 +171,22 @@ class SimpleGADriver(Driver):
         for name, meta in self._designvars.items():
             lower, upper = meta['lower'], meta['upper']
             for param in (lower, upper):
-                if param is None or np.all(np.abs(param) >= INF_BOUND):
+                if param is None or np.any(np.isinf(np.atleast_1d(param))):
                     msg = (f"Invalid bounds for design variable '{name}'. When using "
-                           f"{self.__class__.__name__}, values for both 'lower' and 'upper' "
-                           f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
-                           f"but they are: lower={lower}, upper={upper}.")
+                           f"{self.__class__.__name__}, finite values for both 'lower' and "
+                           f"'upper' must be specified, but they are: "
+                           f"lower={lower}, upper={upper}.")
                     raise ValueError(msg)
 
         for name, meta in self._cons.items():
             equals, lower, upper = meta['equals'], meta['lower'], meta['upper']
-            if ((equals is None or np.all(np.abs(equals) >= INF_BOUND)) and
-               (lower is None or np.all(np.abs(lower) >= INF_BOUND)) and
-               (upper is None or np.all(np.abs(upper) >= INF_BOUND))):
+            eq_unbounded = equals is None or np.all(np.isinf(np.atleast_1d(equals)))
+            lower_unbounded = lower is None or np.all(np.isinf(np.atleast_1d(lower)))
+            upper_unbounded = upper is None or np.all(np.isinf(np.atleast_1d(upper)))
+            if eq_unbounded and lower_unbounded and upper_unbounded:
                 msg = (f"Invalid bounds for constraint '{name}'. "
-                       f"When using {self.__class__.__name__}, the value for 'equals', "
-                       f"'lower' or 'upper' must be specified between +/-INF_BOUND "
-                       f"({INF_BOUND}), but they are: "
+                       f"When using {self.__class__.__name__}, a finite value for 'equals', "
+                       f"'lower' or 'upper' must be specified, but they are: "
                        f"equals={equals}, lower={lower}, upper={upper}.")
                 raise ValueError(msg)
 
@@ -494,9 +493,6 @@ class SimpleGADriver(Driver):
             i, j = self._desvar_idx[name]
             self._set_design_var(name, x[i:j])
 
-        # a very large number, but smaller than the result of nan_to_num in Numpy
-        almost_inf = INF_BOUND
-
         # Execute the model
         with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
             self.iter_count += 1
@@ -541,13 +537,13 @@ class SimpleGADriver(Driver):
                 constraint_violations = np.array([])
                 for name, val in self.get_constraint_values().items():
                     con = self._cons[name]
-                    # The not used fields will either None or a very large number
-                    has_lower_con = (con['lower'] is not None) and \
-                        np.any(con['lower'] > -almost_inf)
-                    has_upper_con = (con['upper'] is not None) and \
-                        np.any(con['upper'] < almost_inf)
-                    has_eq_con = (con['equals'] is not None) and \
-                        np.any(np.abs(con['equals']) < almost_inf)
+                    # None means unbounded; np.inf also means unbounded
+                    has_lower_con = con['lower'] is not None and \
+                        not np.all(np.isneginf(np.atleast_1d(con['lower'])))
+                    has_upper_con = con['upper'] is not None and \
+                        not np.all(np.isposinf(np.atleast_1d(con['upper'])))
+                    has_eq_con = con['equals'] is not None and \
+                        not np.all(np.isinf(np.atleast_1d(con['equals'])))
                     if has_lower_con:
                         lb_diff = val - con['lower']
                         lb_violation = np.array([0. if d >= 0 else abs(d) for d in lb_diff])

--- a/openmdao/drivers/modopt_driver.py
+++ b/openmdao/drivers/modopt_driver.py
@@ -848,15 +848,15 @@ class modOptDriver(Driver):
 
         # Collect design variable information (initial values and bounds)
         x_info = OrderedDict()
-        lower_dv, upper_dv, _ = self._autoscaler.get_bounds_scaling('design_var')
+        dv_bounds = self._autoscaler.get_bounds_scaling('design_var')
         use_bounds = (opt in _bounds_optimizers)
         for name, meta in self._designvars.items():
             x_info[name] = {}
             x_info[name]['init'] = desvar_vals[name]
 
             if use_bounds:
-                x_info[name]['lower'] = lower_dv[name]
-                x_info[name]['upper'] = upper_dv[name]
+                x_info[name]['lower'] = dv_bounds[name].lower
+                x_info[name]['upper'] = dv_bounds[name].upper
             else:
                 x_info[name]['lower'] = None
                 x_info[name]['upper'] = None
@@ -920,7 +920,7 @@ class modOptDriver(Driver):
                 self._lincongrad_cache = None
 
             # Process constraints and organize into linear and nonlinear categories
-            lower_con, upper_con, equals_con = self._autoscaler.get_bounds_scaling('constraint')
+            con_bounds = self._autoscaler.get_bounds_scaling('constraint')
             for name, meta in self._cons.items():
                 if meta['indices'] is not None:
                     meta['size'] = size = meta['indices'].indexed_src_size
@@ -931,27 +931,27 @@ class modOptDriver(Driver):
                 if meta['linear']:
                     if meta['equals'] is not None:
                         lin_con_bounds[name] = {
-                            'lower': equals_con[name],
-                            'upper': equals_con[name],
+                            'lower': con_bounds[name].equals,
+                            'upper': con_bounds[name].equals,
                             'size': size
                         }
                     else:
                         lin_con_bounds[name] = {
-                            'lower': lower_con[name],
-                            'upper': upper_con[name],
+                            'lower': con_bounds[name].lower,
+                            'upper': con_bounds[name].upper,
                             'size': size
                         }
                 else:
                     if meta['equals'] is not None:
                         nl_con_bounds[name] = {
-                            'lower': equals_con[name],
-                            'upper': equals_con[name],
+                            'lower': con_bounds[name].equals,
+                            'upper': con_bounds[name].equals,
                             'size': size
                         }
                     else:
                         nl_con_bounds[name] = {
-                            'lower': lower_con[name],
-                            'upper': upper_con[name],
+                            'lower': con_bounds[name].lower,
+                            'upper': con_bounds[name].upper,
                             'size': size
                         }
 

--- a/openmdao/drivers/pymoo_driver.py
+++ b/openmdao/drivers/pymoo_driver.py
@@ -76,7 +76,6 @@ import sys
 import importlib
 import numpy as np
 from openmdao.core.driver import Driver, RecordingDebugging
-from openmdao.core.constants import INF_BOUND
 from openmdao.utils.mpi import MPI
 try:
     import pymoo
@@ -823,7 +822,7 @@ class pymooDriver(Driver):
         # Collect design variable information (initial values and bounds)
         x_info = {'vars': [], 'upper': np.full(ndesvar, 1e30),
                   'lower': np.full(ndesvar, -1e30), 'indices': []}
-        lower_dv, upper_dv, _ = self._autoscaler.get_bounds_scaling('design_var')
+        dv_bounds = self._autoscaler.get_bounds_scaling('design_var')
         current_idx = 0
         for name, meta in self._designvars.items():
             x_info['vars'].append(name)
@@ -839,8 +838,10 @@ class pymooDriver(Driver):
                 x_info['lower'][current_indices] = meta['lower']
                 x_info['upper'][current_indices] = meta['upper']
             else:
-                x_info['lower'][current_indices] = lower_dv[name]
-                x_info['upper'][current_indices] = upper_dv[name]
+                x_info['lower'][current_indices] = -1e30 if dv_bounds[name].lower is None \
+                    else dv_bounds[name].lower
+                x_info['upper'][current_indices] = 1e30 if dv_bounds[name].upper is None \
+                    else dv_bounds[name].upper
             current_idx += size
 
         # Determine total number of constraints
@@ -856,9 +857,11 @@ class pymooDriver(Driver):
                 if meta['equals'] is not None:
                     neqcons += size
                 else:
-                    if np.any(meta['upper'] < INF_BOUND):
+                    if meta['upper'] is not None and \
+                            not np.all(np.isposinf(np.atleast_1d(meta['upper']))):
                         nieqcons += size
-                    if np.any(meta['lower'] > -INF_BOUND):
+                    if meta['lower'] is not None and \
+                            not np.all(np.isneginf(np.atleast_1d(meta['lower']))):
                         nieqcons += size
 
         # Collect constraint information
@@ -867,7 +870,7 @@ class pymooDriver(Driver):
         current_eq_idx = 0
         current_ieq_idx = 0
         if opt in _constraint_optimizers:
-            lower_con, upper_con, equals_con = self._autoscaler.get_bounds_scaling('constraint')
+            con_bounds = self._autoscaler.get_bounds_scaling('constraint')
             for name, meta in self._cons.items():
                 if meta['indices'] is not None:
                     size = meta['indices'].indexed_src_size
@@ -879,25 +882,27 @@ class pymooDriver(Driver):
                     current_eq_indices = list(range(current_eq_idx, current_eq_idx + size))
                     eq_con_info['vars'].append(name)
                     eq_con_info['indices'].append(current_eq_indices)
-                    eq_con_info['equals'][current_eq_indices] = equals_con[name]
+                    eq_con_info['equals'][current_eq_indices] = con_bounds[name].equals
                     current_eq_idx += size
 
                 else:
                     # Need to log upper and lower as separate inequality constraints
-                    if np.any(meta['upper'] < INF_BOUND):
+                    if meta['upper'] is not None and \
+                            not np.all(np.isposinf(np.atleast_1d(meta['upper']))):
                         current_ieq_indices = list(range(current_ieq_idx, current_ieq_idx + size))
                         ieq_con_info['vars'].append(name)
                         ieq_con_info['indices'].append(current_ieq_indices)
                         ieq_con_info['is_upper'].append(True)
-                        ieq_con_info['bound'][current_ieq_indices] = upper_con[name]
+                        ieq_con_info['bound'][current_ieq_indices] = con_bounds[name].upper
                         current_ieq_idx += size
 
-                    if np.any(meta['lower'] > -INF_BOUND):
+                    if meta['lower'] is not None and \
+                            not np.all(np.isneginf(np.atleast_1d(meta['lower']))):
                         current_ieq_indices = list(range(current_ieq_idx, current_ieq_idx + size))
                         ieq_con_info['vars'].append(name)
                         ieq_con_info['indices'].append(current_ieq_indices)
                         ieq_con_info['is_upper'].append(False)
-                        ieq_con_info['bound'][current_ieq_indices] = lower_con[name]
+                        ieq_con_info['bound'][current_ieq_indices] = con_bounds[name].lower
                         current_ieq_idx += size
 
         # Collect objective information

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -178,6 +178,8 @@ class pyOptSparseDriver(Driver):
         The pyoptsparse Optimization class, lazily imported.
     """
 
+    _inf_bound = 1.0E30
+
     def __init__(self, **kwargs):
         """
         Initialize pyopt.
@@ -391,19 +393,21 @@ class pyOptSparseDriver(Driver):
         input_vals = self.get_design_var_values()
 
         # Get scaled design variable bounds from autoscaler
-        lower_dv, upper_dv, _ = self._autoscaler.get_bounds_scaling('design_var')
+        dv_bounds = self._autoscaler.get_bounds_scaling('design_var')
 
         for name, meta in self._designvars.items():
             # translate absolute var names to promoted names for pyoptsparse
             size = meta['global_size'] if meta['distributed'] else meta['size']
+            lb = self._to_driver_bound(dv_bounds[name].lower)
+            ub = self._to_driver_bound(dv_bounds[name].upper)
             if pyoptsparse_version is None or pyoptsparse_version < Version('2.6.1'):
                 opt_prob.addVarGroup(name, size, type='c',
                                      value=input_vals[name],
-                                     lower=lower_dv[name], upper=upper_dv[name])
+                                     lower=lb, upper=ub)
             else:
                 opt_prob.addVarGroup(name, size, varType='c',
                                      value=input_vals[name],
-                                     lower=lower_dv[name], upper=upper_dv[name])
+                                     lower=lb, upper=ub)
 
         if pyoptsparse_version is None or pyoptsparse_version < Version('2.5.1'):
             opt_prob.finalizeDesignVariables()
@@ -457,14 +461,14 @@ class pyOptSparseDriver(Driver):
                 del self._responses[name]
 
         # Get scaled constraint bounds from autoscaler
-        lower_con, upper_con, equals_con = self._autoscaler.get_bounds_scaling('constraint')
+        con_bounds = self._autoscaler.get_bounds_scaling('constraint')
 
         eqcons = {n: m for n, m in self._cons.items() if m['equals'] is not None}
         if eqcons:
             # Add all equality constraints
             for name, meta in eqcons.items():
                 size = meta['global_size'] if meta['distributed'] else meta['size']
-                lower = upper = equals_con[name]
+                lower = upper = self._to_driver_bound(con_bounds[name].equals)
 
                 # set equality constraints as reverse seeds to see what dvs are relevant
                 with relevance.seeds_active(rev_seeds=meta['source']):
@@ -473,9 +477,10 @@ class pyOptSparseDriver(Driver):
                         wrts = [v for v in lin_dvs
                                 if relevance.is_relevant(lin_dvs[v]['source'])]
                         jac = {w: _lin_jacs[name][w] for w in wrts}
+                        yi = _y_intercepts[name]
                         opt_prob.addConGroup(name, size,
-                                             lower=lower - _y_intercepts[name],
-                                             upper=upper - _y_intercepts[name],
+                                             lower=None if lower is None else lower - yi,
+                                             upper=None if upper is None else upper - yi,
                                              linear=True, wrt=wrts, jac=jac)
                     else:
                         wrts = [v for v in nl_dvs
@@ -498,8 +503,8 @@ class pyOptSparseDriver(Driver):
                 size = meta['global_size'] if meta['distributed'] else meta['size']
 
                 # Bounds - double sided is supported (scaled bounds from autoscaler)
-                lower = lower_con[name]
-                upper = upper_con[name]
+                lower = self._to_driver_bound(con_bounds[name].lower)
+                upper = self._to_driver_bound(con_bounds[name].upper)
 
                 # set inequality constraints as reverse seeds to see what dvs are relevant
                 with relevance.seeds_active(rev_seeds=(meta['source'],)):
@@ -508,9 +513,10 @@ class pyOptSparseDriver(Driver):
                         wrts = [n for n, meta in lin_dvs.items()
                                 if relevance.is_relevant(meta['source'])]
                         jac = {w: _lin_jacs[name][w] for w in wrts}
+                        yi = _y_intercepts[name]
                         opt_prob.addConGroup(name, size,
-                                             upper=upper - _y_intercepts[name],
-                                             lower=lower - _y_intercepts[name],
+                                             lower=None if lower is None else lower - yi,
+                                             upper=None if upper is None else upper - yi,
                                              linear=True, wrt=wrts, jac=jac)
                     else:
                         wrts = [n for n, meta in nl_dvs.items()

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -9,7 +9,6 @@ import numpy as np
 from scipy import __version__ as scipy_version
 from scipy.optimize import minimize
 
-from openmdao.core.constants import INF_BOUND
 from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.core.group import Group
 from openmdao.utils.class_util import WeakMethodWrapper
@@ -133,6 +132,11 @@ class ScipyOptimizeDriver(Driver):
         Cached array for setting design variables.
     """
 
+    # Optimizers in _supports_new_style use a trust-region polish step that does not
+    # converge reliably with IEEE infinity in NonlinearConstraint/LinearConstraint bounds.
+    # Clamp ±inf to this value before passing bounds to those constraint classes.
+    _inf_bound_new_style = 1.0E30
+
     def __init__(self, **kwargs):
         """
         Initialize the ScipyOptimizeDriver.
@@ -241,8 +245,11 @@ class ScipyOptimizeDriver(Driver):
             for name, meta in self._designvars.items():
                 lower = meta['lower']
                 upper = meta['upper']
-                if isinstance(lower, np.ndarray) or lower > -INF_BOUND \
-                        or isinstance(upper, np.ndarray) or upper < INF_BOUND:
+                lower_bounded = isinstance(lower, np.ndarray) or \
+                    (lower is not None and not np.isneginf(lower))
+                upper_bounded = isinstance(upper, np.ndarray) or \
+                    (upper is not None and not np.isposinf(upper))
+                if lower_bounded or upper_bounded:
                     self._cons[name] = meta.copy()
                     self._cons[name]['equals'] = None
                     self._cons[name]['linear'] = True
@@ -306,7 +313,7 @@ class ScipyOptimizeDriver(Driver):
         else:
             bounds = None
 
-        lower_dv, upper_dv, _ = self._autoscaler.get_bounds_scaling('design_var')
+        dv_bounds = self._autoscaler.get_bounds_scaling('design_var')
 
         for name, meta in self._designvars.items():
             size = meta['global_size'] if meta['distributed'] else meta['size']
@@ -315,15 +322,15 @@ class ScipyOptimizeDriver(Driver):
 
             # Bounds if our optimizer supports them
             if use_bounds:
-                meta_low = lower_dv[name]
-                meta_high = upper_dv[name]
+                meta_low = dv_bounds[name].lower
+                meta_high = dv_bounds[name].upper
                 for j in range(size):
-                    p_low = meta_low[j]
-                    p_high = meta_high[j]
+                    p_low = None if meta_low is None else meta_low[j]
+                    p_high = None if meta_high is None else meta_high[j]
 
-                    if p_low <= -INF_BOUND:
+                    if p_low is not None and np.isneginf(p_low):
                         p_low = None
-                    if p_high >= INF_BOUND:
+                    if p_high is not None and np.isposinf(p_high):
                         p_high = None
 
                     bounds.append((p_low, p_high))
@@ -364,7 +371,7 @@ class ScipyOptimizeDriver(Driver):
             else:
                 self._lincongrad_cache = None
 
-            lower_con, upper_con, equals_con = self._autoscaler.get_bounds_scaling('constraint')
+            con_bounds = self._autoscaler.get_bounds_scaling('constraint')
 
             # map constraints to index and instantiate constraints for scipy
             for name, meta in self._cons.items():
@@ -372,9 +379,9 @@ class ScipyOptimizeDriver(Driver):
                     meta['size'] = size = meta['indices'].indexed_src_size
                 else:
                     size = meta['global_size'] if meta['distributed'] else meta['size']
-                upper = upper_con[name]
-                lower = lower_con[name]
-                equals = equals_con[name] if meta['equals'] is not None else None
+                upper = con_bounds[name].upper
+                lower = con_bounds[name].lower
+                equals = con_bounds[name].equals
                 linear = name in lincons
 
                 if linear:
@@ -396,11 +403,12 @@ class ScipyOptimizeDriver(Driver):
                                'above. The installed version is {}')
                         raise ImportError(msg.format(scipy_version))
 
+                    inf_b = self._inf_bound_new_style
                     if equals is not None:
-                        lb = ub = equals
+                        lb = ub = np.clip(equals, -inf_b, inf_b)
                     else:
-                        lb = lower
-                        ub = upper
+                        lb = np.full(size, -inf_b) if lower is None else np.maximum(lower, -inf_b)
+                        ub = np.full(size, inf_b) if upper is None else np.minimum(upper, inf_b)
                     
                     if linear:
                         # LinearConstraint
@@ -414,8 +422,8 @@ class ScipyOptimizeDriver(Driver):
                             # TODO add option for Hessian
                             # Double-sided constraints are accepted by the algorithm
                             args = [name, False, j]
-                            lb_j = np.maximum(lb[j], -INF_BOUND)
-                            ub_j = np.minimum(ub[j], INF_BOUND)
+                            lb_j = lb[j]
+                            ub_j = ub[j]
                             con = NonlinearConstraint(
                                 fun=signature_extender(
                                     WeakMethodWrapper(self, '_con_val_func'), args),
@@ -441,13 +449,13 @@ class ScipyOptimizeDriver(Driver):
                         con_dict['args'] = [name, False, j]
                         constraints.append(con_dict)
 
-                        if isinstance(upper, np.ndarray):
-                            upper = upper[j]
+                        upper_j = None if upper is None else (
+                            upper[j] if isinstance(upper, np.ndarray) else upper)
+                        lower_j = None if lower is None else (
+                            lower[j] if isinstance(lower, np.ndarray) else lower)
 
-                        if isinstance(lower, np.ndarray):
-                            lower = lower[j]
-
-                        dblcon = (upper < INF_BOUND) and (lower > -INF_BOUND)
+                        dblcon = (upper_j is not None and not np.isposinf(upper_j)) and \
+                                 (lower_j is not None and not np.isneginf(lower_j))
 
                         # Add extra constraint if double-sided
                         if dblcon:
@@ -704,19 +712,21 @@ class ScipyOptimizeDriver(Driver):
         cons = self._con_cache
         meta = self._cons[name]
 
-        lower_con, upper_con, equals_con = self._autoscaler.get_bounds_scaling('constraint')
+        con_bounds = self._autoscaler.get_bounds_scaling('constraint')
 
         # Equality constraints
         if meta['equals'] is not None:
-            eq = equals_con[name]
+            eq = con_bounds[name].equals
             return cons[name][idx] - eq[idx]
 
         # Note, scipy defines constraints to be satisfied when positive,
         # which is the opposite of OpenMDAO.
-        upper = upper_con[name][idx]
-        lower = lower_con[name][idx]
+        upper_arr = con_bounds[name].upper
+        lower_arr = con_bounds[name].lower
+        upper = np.inf if upper_arr is None else upper_arr[idx]
+        lower = -np.inf if lower_arr is None else lower_arr[idx]
 
-        if dbl or (lower <= -INF_BOUND):
+        if dbl or np.isneginf(lower):
             return upper - cons[name][idx]
         else:
             return cons[name][idx] - lower
@@ -744,8 +754,6 @@ class ScipyOptimizeDriver(Driver):
             grad = self._compute_totals(of=self._obj_and_nlcons, wrt=self._dvlist,
                                         return_format=self._total_jac_format)
             self._grad_cache = grad
-            if not np.all(np.isfinite(grad)):
-                print(f'DEBUG _gradfunc: NaN/Inf in grad shape={grad.shape}:\n{grad}')
 
             # First time through, check for zero row/col.
             if self._check_jac and self._total_jac is not None:
@@ -814,7 +822,7 @@ class ScipyOptimizeDriver(Driver):
         if isinstance(lower, np.ndarray):
             lower = lower[idx]
 
-        if dbl or (lower <= -INF_BOUND):
+        if dbl or lower is None or np.isneginf(lower):
             return -grad[grad_idx, :]
         else:
             return grad[grad_idx, :]

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import openmdao.api as om
 
-from openmdao.core.constants import INF_BOUND
 
 from openmdao.drivers.differential_evolution_driver import DifferentialEvolution
 
@@ -42,10 +41,10 @@ extra_prints = False  # enable printing results
 def _test_func_name(func, num, param):
     args = []
     for p in param.args:
-        if p and p == INF_BOUND:
-            args.append('INF_BOUND')
-        elif p and p == -INF_BOUND:
-            args.append('-INF_BOUND')
+        if p is not None and np.isscalar(p) and np.isposinf(p):
+            args.append('inf')
+        elif p is not None and np.isscalar(p) and np.isneginf(p):
+            args.append('-inf')
         else:
             args.append(str(p))
     return func.__name__ + '_' + '_'.join(args)
@@ -380,11 +379,11 @@ class TestDifferentialEvolution(unittest.TestCase):
 
     @parameterized.expand([
         (None, None),
-        (INF_BOUND, INF_BOUND),
-        (None, INF_BOUND),
-        (None, -INF_BOUND),
-        (INF_BOUND, None),
-        (-INF_BOUND, None),
+        (np.inf, np.inf),
+        (None, np.inf),
+        (None, -np.inf),
+        (np.inf, None),
+        (-np.inf, None),
     ],
     name_func=_test_func_name)
     def test_inf_desvar(self, lower, upper):
@@ -404,16 +403,9 @@ class TestDifferentialEvolution(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             prob.final_setup()
 
-        # A value of None for lower and upper is changed to +/- INF_BOUND in add_design_var()
-        if lower is None:
-            lower = -INF_BOUND
-        if upper is None:
-            upper = INF_BOUND
-
         msg = ("Invalid bounds for design variable 'x'. When using "
-               "DifferentialEvolutionDriver, values for both 'lower' and 'upper' "
-               f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
-               f"but they are: lower={lower}, upper={upper}.")
+               "DifferentialEvolutionDriver, finite values for both 'lower' and "
+               f"'upper' must be specified, but they are: lower={lower}, upper={upper}.")
 
         self.maxDiff = None
         self.assertEqual(err.exception.args[0], msg)
@@ -827,9 +819,9 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
         assert_near_equal(p.get_val('exec.z')[50], -1000)
 
     @parameterized.expand([
-        (None, -INF_BOUND, INF_BOUND),
-        (INF_BOUND, None, None),
-        (-INF_BOUND, None, None),
+        (None, -np.inf, np.inf),
+        (np.inf, None, None),
+        (-np.inf, None, None),
     ],
     name_func=_test_func_name)
     def test_inf_constraints(self, equals, lower, upper):
@@ -854,16 +846,9 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             prob.final_setup()
 
-        # A value of None for lower and upper is changed to +/- INF_BOUND in add_constraint()
-        if lower is None:
-            lower = -INF_BOUND
-        if upper is None:
-            upper = INF_BOUND
-
         msg = ("Invalid bounds for constraint 'const.g'. "
-               "When using DifferentialEvolutionDriver, the value for "
-               "'equals', 'lower' or 'upper' must be specified between "
-               f"+/-INF_BOUND ({INF_BOUND}), but they are: "
+               "When using DifferentialEvolutionDriver, a finite value for 'equals', "
+               "'lower' or 'upper' must be specified, but they are: "
                f"equals={equals}, lower={lower}, upper={upper}.")
 
         self.maxDiff = None

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import openmdao.api as om
 
-from openmdao.core.constants import INF_BOUND
 
 from openmdao.drivers.genetic_algorithm_driver import GeneticAlgorithm
 
@@ -44,10 +43,10 @@ extra_prints = False  # enable printing results
 def _test_func_name(func, num, param):
     args = []
     for p in param.args:
-        if p and p == INF_BOUND:
-            args.append('INF_BOUND')
-        elif p and p == -INF_BOUND:
-            args.append('-INF_BOUND')
+        if p is not None and np.isscalar(p) and np.isposinf(p):
+            args.append('inf')
+        elif p is not None and np.isscalar(p) and np.isneginf(p):
+            args.append('-inf')
         else:
             args.append(str(p))
     return func.__name__ + '_' + '_'.join(args)
@@ -526,11 +525,11 @@ class TestSimpleGA(unittest.TestCase):
 
     @parameterized.expand([
         (None, None),
-        (INF_BOUND, INF_BOUND),
-        (None, INF_BOUND),
-        (None, -INF_BOUND),
-        (INF_BOUND, None),
-        (-INF_BOUND, None),
+        (np.inf, np.inf),
+        (None, np.inf),
+        (None, -np.inf),
+        (np.inf, None),
+        (-np.inf, None),
     ],
     name_func=_test_func_name)
     def test_inf_desvar(self, lower, upper):
@@ -550,16 +549,9 @@ class TestSimpleGA(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             prob.final_setup()
 
-        # A value of None for lower and upper is changed to +/- INF_BOUND in add_design_var()
-        if lower is None:
-            lower = -INF_BOUND
-        if upper is None:
-            upper = INF_BOUND
-
         msg = ("Invalid bounds for design variable 'x'. When using "
-               "SimpleGADriver, values for both 'lower' and 'upper' "
-               f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
-               f"but they are: lower={lower}, upper={upper}.")
+               "SimpleGADriver, finite values for both 'lower' and "
+               f"'upper' must be specified, but they are: lower={lower}, upper={upper}.")
 
         self.maxDiff = None
         self.assertEqual(err.exception.args[0], msg)
@@ -1020,9 +1012,9 @@ class TestConstrainedSimpleGA(unittest.TestCase):
         assert_near_equal(p.get_val('exec.z')[50], -400)
 
     @parameterized.expand([
-        (None, -INF_BOUND, INF_BOUND),
-        (INF_BOUND, None, None),
-        (-INF_BOUND, None, None),
+        (None, -np.inf, np.inf),
+        (np.inf, None, None),
+        (-np.inf, None, None),
     ],
     name_func=_test_func_name)
     def test_inf_constraints(self, equals, lower, upper):
@@ -1047,16 +1039,9 @@ class TestConstrainedSimpleGA(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             prob.final_setup()
 
-        # A value of None for lower and upper is changed to +/- INF_BOUND in add_constraint()
-        if lower is None:
-            lower = -INF_BOUND
-        if upper is None:
-            upper = INF_BOUND
-
         msg = ("Invalid bounds for constraint 'const.g'. "
-               "When using SimpleGADriver, the value for 'equals', "
-               "'lower' or 'upper' must be specified between "
-               f"+/-INF_BOUND ({INF_BOUND}), but they are: "
+               "When using SimpleGADriver, a finite value for 'equals', "
+               "'lower' or 'upper' must be specified, but they are: "
                f"equals={equals}, lower={lower}, upper={upper}.")
 
         self.maxDiff = None

--- a/openmdao/drivers/tests/test_modopt_driver.py
+++ b/openmdao/drivers/tests/test_modopt_driver.py
@@ -1364,8 +1364,8 @@ class TestModOptDriver(unittest.TestCase):
         prob.run_driver()
 
         # Check expected responses are met
-        assert_near_equal(prob['f_xy'], -27.0, 1e-4)
-        assert_near_equal(prob['c'], 0.0, 1e-4)
+        assert_near_equal(prob['f_xy'], -27.0, 1e-3)
+        assert_near_equal(prob['c'], 0.0, 1e-3)
 
     @require_modopt_optimizer('COBYQA')
     def test_cobyqa_gradient_free(self):
@@ -1398,8 +1398,8 @@ class TestModOptDriver(unittest.TestCase):
         prob.run_driver()
 
         # Check expected responses are met
-        assert_near_equal(prob['f_xy'], -27.0, 1e-4)
-        assert_near_equal(prob['c'], 0.0, 1e-4)
+        assert_near_equal(prob['f_xy'], -27.0, 1e-3)
+        assert_near_equal(prob['c'], 0.0, 1e-3)
 
     @require_modopt_optimizer('NelderMead')
     def test_neldermead_unconstrained(self):
@@ -1668,6 +1668,67 @@ class TestModOptDriver(unittest.TestCase):
         # Check that supports dict is read-only
         with self.assertRaises(KeyError):
             prob.driver.supports['equality_constraints'] = False
+
+    def test_inf_bounds_issue_3772(self):
+        """
+        Test that unbounded constraint bounds are passed to modopt as np.inf, not 1e30.
+
+        Regression test for https://github.com/OpenMDAO/OpenMDAO/issues/3772.
+        A one-sided constraint (lower only) should produce upper=np.inf in the
+        modopt problem, not the INF_BOUND sentinel of 1e30.
+        """
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x + y'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = modOptDriver(optimizer='SLSQP')
+        prob.driver.options['disp'] = False
+        prob.driver.options['turn_off_outputs'] = True
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_objective('f_xy')
+        model.add_constraint('c', lower=-15.0)
+
+        prob.setup()
+        prob.run_driver()
+
+        self.assertTrue(prob.driver.result.success, 'Optimization did not converge')
+        self.assertGreaterEqual(prob['c'], -15.0 - 1e-4)
+
+        # Verify that modopt received None or np.inf (not 1e30) as the upper bound
+        # for the one-sided lower constraint (issue #3772)
+        upper = prob.driver._mo_prob.nl_con_bounds['c']['upper']
+        self.assertTrue(upper is None or np.all(np.isposinf(np.atleast_1d(upper))),
+                        f'Expected None or np.inf upper bound for one-sided constraint, got {upper}')
+
+        # Also verify None or -np.inf lower bound on an upper-only constraint
+        prob2 = om.Problem()
+        model2 = prob2.model
+        model2.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model2.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model2.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model2.add_subsystem('con', om.ExecComp('c = x + y'), promotes=['*'])
+        prob2.set_solver_print(level=0)
+        prob2.driver = modOptDriver(optimizer='SLSQP')
+        prob2.driver.options['disp'] = False
+        prob2.driver.options['turn_off_outputs'] = True
+        model2.add_design_var('x', lower=-50.0, upper=50.0)
+        model2.add_design_var('y', lower=-50.0, upper=50.0)
+        model2.add_objective('f_xy')
+        model2.add_constraint('c', upper=0.0)
+        prob2.setup()
+        prob2.run_driver()
+
+        lower = prob2.driver._mo_prob.nl_con_bounds['c']['lower']
+        self.assertTrue(lower is None or np.all(np.isneginf(np.atleast_1d(lower))),
+                        f'Expected None or -np.inf lower bound for one-sided constraint, got {lower}')
 
 
 @unittest.skipUnless(MODOPT_INSTALLED, 'modOpt is not installed')

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -19,11 +19,9 @@ from collections.abc import Iterable
 
 import numpy as np
 
-from openmdao.core.constants import INF_BOUND, _UNDEFINED
+from openmdao.core.constants import _UNDEFINED
 from openmdao.utils.array_utils import shape_to_len
 
-
-_float_inf = float('inf')
 
 
 def ensure_compatible(name, value, shape=None, indices=None, default_shape=(1,)):
@@ -314,10 +312,7 @@ def format_as_float_or_array(name, values, val_if_none=0.0, flatten=False):
     """
     # Convert adder to ndarray/float as necessary
     if isinstance(values, float):
-        if values == _float_inf:
-            values = INF_BOUND
-        elif values == -_float_inf:
-            values = -INF_BOUND
+        pass  # float values including inf pass through unchanged
     elif isinstance(values, np.ndarray):
         if flatten:
             values = values.flatten()

--- a/openmdao/vectors/bound_map.py
+++ b/openmdao/vectors/bound_map.py
@@ -1,0 +1,129 @@
+"""Name-keyed mapping of optimizer bounds, storing None for entirely-unbounded variables."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class _VarBounds:
+    """
+    Bounds for a single optimizer variable.
+
+    Attributes
+    ----------
+    lower : ndarray or None
+        Lower bound array, or None if entirely unbounded below.
+    upper : ndarray or None
+        Upper bound array, or None if entirely unbounded above.
+    equals : ndarray or None
+        Equality value array, or None if not an equality constraint.
+    """
+
+    lower: object
+    upper: object
+    equals: object
+
+
+def _compact(arr, is_lower):
+    """
+    Return arr, or None if all elements are the unbounded infinity for this direction.
+
+    Parameters
+    ----------
+    arr : ndarray or None
+        Bound array.
+    is_lower : bool
+        True if this is a lower bound (checks for all -inf), False for upper (all +inf).
+
+    Returns
+    -------
+    ndarray or None
+    """
+    if arr is None:
+        return None
+    arr = np.asarray(arr, dtype=float).ravel()
+    if is_lower:
+        return None if np.all(np.isneginf(arr)) else arr
+    return None if np.all(np.isposinf(arr)) else arr
+
+
+class BoundMap:
+    """
+    Name-keyed mapping of optimizer bounds.
+
+    Each entry holds lower, upper, and equals bounds for one variable. Entirely-unbounded
+    directions are stored as None rather than an array of ±inf, avoiding unnecessary
+    memory allocation for large unbounded variables.
+
+    Attributes
+    ----------
+    _data : dict[str, _VarBounds]
+        Per-variable bounds objects.
+    """
+
+    def __init__(self):
+        """Initialize BoundMap."""
+        self._data = {}
+
+    def set(self, name, lower, upper, equals, size):
+        """
+        Store bounds for a single variable.
+
+        Parameters
+        ----------
+        name : str
+            Variable name.
+        lower : ndarray or None
+            Lower bound in scaled units, or None if entirely unbounded below.
+        upper : ndarray or None
+            Upper bound in scaled units, or None if entirely unbounded above.
+        equals : ndarray or None
+            Equality value in scaled units, or None if not an equality constraint.
+        size : int
+            Number of elements in the variable (used for broadcasting scalars).
+        """
+        self._data[name] = _VarBounds(
+            _compact(lower, is_lower=True),
+            _compact(upper, is_lower=False),
+            equals if equals is None else np.asarray(equals, dtype=float).ravel(),
+        )
+
+    def __getitem__(self, name):
+        """
+        Return the _VarBounds for a variable.
+
+        Parameters
+        ----------
+        name : str
+            Variable name.
+
+        Returns
+        -------
+        _VarBounds
+            Bounds object with .lower, .upper, .equals attributes.
+
+        Raises
+        ------
+        KeyError
+            If variable name not found.
+        """
+        if name not in self._data:
+            raise KeyError(f"Variable '{name}' not found in BoundMap")
+        return self._data[name]
+
+    def __contains__(self, name):
+        """Return True if name is in the dict."""
+        return name in self._data
+
+    def __iter__(self):
+        """Iterate over variable names."""
+        return iter(self._data)
+
+    def keys(self):
+        """Return variable names."""
+        return self._data.keys()
+
+    def items(self):
+        """Iterate over (name, _VarBounds) pairs."""
+        return self._data.items()

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -22,7 +22,6 @@ except ImportError:
     mpl = None
 
 
-from openmdao.core.constants import INF_BOUND
 from openmdao.utils.mpi import MPI
 from openmdao.visualization.tables.table_builder import generate_table
 
@@ -378,13 +377,13 @@ def _make_dvcons_table(meta_dict, vals_dict, kind,
                 else:
                     row[col_name] = max_val_as_str
             elif col_name == 'lower':
-                if meta[col_name] is None or np.all(meta[col_name] == -INF_BOUND):
+                if meta[col_name] is None or np.all(np.isneginf(np.atleast_1d(meta[col_name]))):
                     row[col_name] = None
                 else:
                     lower_val = np.mean(meta[col_name])
                     row[col_name] = _indicate_value_is_derived_from_array(lower_val, meta[col_name])
             elif col_name == 'upper':
-                if meta[col_name] is None or np.all(meta[col_name] == INF_BOUND):
+                if meta[col_name] is None or np.all(np.isposinf(np.atleast_1d(meta[col_name]))):
                     row[col_name] = None
                 else:
                     upper_val = np.mean(meta[col_name])
@@ -522,14 +521,14 @@ def _desvar_or_ineq_constraint_sparkline(ax, meta, val):
 
     # get array for the lower and upper bounds
     if meta['lower'] is None:
-        _lower = (-INF_BOUND * np.ones_like(val)[indices]).ravel()
+        _lower = np.full_like(np.asarray(val).ravel(), -np.inf)
     elif isinstance(meta['lower'], float):
         _lower = (meta['lower'] * np.ones_like(val)[indices]).ravel()
     else:
         _lower = np.asarray(meta['lower']).ravel()
 
     if meta['upper'] is None:
-        _upper = (INF_BOUND * np.ones_like(val)[indices]).ravel()
+        _upper = np.full_like(np.asarray(val).ravel(), np.inf)
     elif isinstance(meta['upper'], float):
         _upper = (meta['upper'] * np.ones_like(val)[indices]).ravel()
     else:
@@ -568,19 +567,18 @@ def _desvar_or_ineq_constraint_sparkline(ax, meta, val):
     ax.plot(ar, _val, '-o', markersize=_plot_marker_size, color=_value_plot_color,
             linewidth=_plot_value_linewidth)
 
-    # Need to do this because of a bug in matplotlib. If the upper or lowers include INF_BOUND
-    #  it affects how the other side of the fill_between is drawn
+    # Need to clip before plotting so matplotlib fill_between handles infinite bounds correctly
     _lower = np.clip(_lower, ymin_plot, ymax_plot)
     _upper = np.clip(_upper, ymin_plot, ymax_plot)
 
     # plot lower area, if exists
-    if not (isinstance(meta['lower'], float) and meta['lower'] == -INF_BOUND):
+    if meta['lower'] is not None and not np.all(np.isneginf(np.atleast_1d(meta['lower']))):
         ax.fill_between(ar, ymin_plot, _lower, color=_out_of_bounds_plot_color,
                         hatch=_out_of_bounds_plot_hatch_pattern, alpha=_out_of_bounds_plot_alpha)
         ax.plot(ar, _lower, color=_out_of_bounds_plot_color, linewidth=_plot_value_linewidth)
 
     # plot upper area, if exists
-    if not (isinstance(meta['upper'], float) and meta['upper'] == INF_BOUND):
+    if meta['upper'] is not None and not np.all(np.isposinf(np.atleast_1d(meta['upper']))):
         ax.fill_between(ar, _upper, ymax_plot, color=_out_of_bounds_plot_color,
                         hatch=_out_of_bounds_plot_hatch_pattern, alpha=_out_of_bounds_plot_alpha)
         ax.plot(ar, _upper, color=_out_of_bounds_plot_color, linewidth=_plot_value_linewidth)
@@ -682,10 +680,12 @@ def _constraint_plot(kind, meta, val, width=300):
             pass  # handle other than ndarray, e.g. int
 
     # If lower and upper bounds are None, return an HTML snippet indicating the issue
-    if kind == 'constraint' and meta['upper'] == INF_BOUND and meta['lower'] == -INF_BOUND:
+    upper_is_inf = meta['upper'] is None or np.all(np.isposinf(np.atleast_1d(meta['upper'])))
+    lower_is_inf = meta['lower'] is None or np.all(np.isneginf(np.atleast_1d(meta['lower'])))
+    if kind == 'constraint' and upper_is_inf and lower_is_inf:
         return '<span class="bounds-unavailable">Both lower and upper bounds are None.</span>'
 
-    if kind == 'desvar' and meta['upper'] == INF_BOUND and meta['lower'] == -INF_BOUND:
+    if kind == 'desvar' and upper_is_inf and lower_is_inf:
         return   # nothing to plot
 
     # Equality constraints are visualized differently
@@ -699,11 +699,11 @@ def _constraint_plot(kind, meta, val, width=300):
 
     # If lower and upper are the same value, visualize the same as an equality constraint
     if (
-        'lower' in meta and meta['lower'] != -INF_BOUND and meta['lower'] is not None
-        and
-        'upper' in meta and meta['upper'] != INF_BOUND and meta['upper'] is not None
-        and
-        meta['lower'] == meta['upper']
+        'lower' in meta and meta['lower'] is not None
+        and not np.all(np.isneginf(np.atleast_1d(meta['lower'])))
+        and 'upper' in meta and meta['upper'] is not None
+        and not np.all(np.isposinf(np.atleast_1d(meta['upper'])))
+        and meta['lower'] == meta['upper']
     ):
         if abs(val - meta['lower']) < _equality_constraint_tolerance:
             html = '<span class="equality-constraint equality-constraint-satisfied">&#10003;</span>'
@@ -716,8 +716,8 @@ def _constraint_plot(kind, meta, val, width=300):
 
     fig, ax = plt.subplots(nrows=1, ncols=1, figsize=_scalar_visual_figsize, dpi=_plot_dpi)
 
-    lower = -INF_BOUND if meta['lower'] is None else meta['lower']
-    upper = INF_BOUND if meta['upper'] is None else meta['upper']
+    lower = -np.inf if meta['lower'] is None else meta['lower']
+    upper = np.inf if meta['upper'] is None else meta['upper']
 
     var_bounds_plot(kind, ax, float(val), lower, upper)
     tmpfile = io.BytesIO()
@@ -781,21 +781,19 @@ def _get_bound_array_min_max(bounds, indices):
     _bounds
         An array representing the bounds.
     _bounds_min
-        The minimum of the bounds, excluding any entries in the _bounds array that
-          equal -INF_BOUND or INF_BOUND. If all the values are those, return INF_BOUND
-          so that when mins are taken that include this value, it doesn't affect the result
+        The minimum of the bounds, excluding any non-finite (inf) entries. If all entries
+          are infinite, return np.inf so that when mins are taken it doesn't affect the result.
     _bounds_max
-        The maximum of the bounds, excluding any entries in the _bounds array that
-          equal -INF_BOUND or INF_BOUND. If all the values are those, return -INF_BOUND
-          so that when maxes are taken that include this value, it doesn't affect the result
+        The maximum of the bounds, excluding any non-finite (inf) entries. If all entries
+          are infinite, return -np.inf so that when maxes are taken it doesn't affect the result.
     """
-    _bounds_no_inf = bounds[np.where(((bounds != -INF_BOUND) & (bounds != INF_BOUND)))]
+    _bounds_no_inf = bounds[np.isfinite(bounds)]
     if _bounds_no_inf.size > 0:
         _bounds_min = np.min(_bounds_no_inf)
         _bounds_max = np.max(_bounds_no_inf)
     else:  # so that when we do min and max on these they are not involved in getting the min/max
-        _bounds_min = INF_BOUND
-        _bounds_max = - INF_BOUND
+        _bounds_min = np.inf
+        _bounds_max = -np.inf
 
     if isinstance(bounds, float):
         _bounds = (bounds * np.ones_like(bounds)[indices]).ravel()
@@ -845,7 +843,7 @@ def var_bounds_plot(kind, ax, value, lower, upper):
     func_val_to_plot_coord = partial(_val_to_plot_coord, lower=lower, upper=upper)
     value_in_plot_coord = func_val_to_plot_coord(value)
 
-    if upper == INF_BOUND:  # there is a lower bound
+    if np.isposinf(upper):  # there is a lower bound
         _draw_in_or_out_bound_section(ax, 0, _plot_x_max / 2, False)
         _draw_in_or_out_bound_section(ax, _plot_x_max / 2, _plot_x_max / 2, True)
         _draw_boundary_label(ax, _plot_x_max / 2,
@@ -864,7 +862,7 @@ def var_bounds_plot(kind, ax, value, lower, upper):
         _draw_pointer_and_label(ax, pointer_plot_coord, pointer_color, value)
         return
 
-    if lower == -INF_BOUND:  # there is an upper bound
+    if np.isneginf(lower):  # there is an upper bound
         _draw_in_or_out_bound_section(ax, 0, _plot_x_max / 2, True)
         _draw_in_or_out_bound_section(ax, _plot_x_max / 2, _plot_x_max / 2, False)
         _draw_boundary_label(ax, _plot_x_max / 2,

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -5,7 +5,6 @@ import numpy as np
 
 import openmdao.api as om
 
-from openmdao.core.constants import INF_BOUND
 from openmdao.core.driver import Driver
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
@@ -30,8 +29,8 @@ except ImportError:
 class TestOptimizationReport(unittest.TestCase):
 
     def setup_problem_and_run_driver(self, driver,
-                                     vars_lower=-INF_BOUND, vars_upper=INF_BOUND,
-                                     cons_lower=-INF_BOUND, cons_upper=INF_BOUND,
+                                     vars_lower=None, vars_upper=None,
+                                     cons_lower=None, cons_upper=None,
                                      final_setup_only=False,
                                      optimizer=None
                                      ):

--- a/openmdao/visualization/realtime_plot/realtime_optimizer_plot.py
+++ b/openmdao/visualization/realtime_plot/realtime_optimizer_plot.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 import re
 
 from openmdao.utils.shell_proc import _is_process_running
-from openmdao.core.constants import INF_BOUND
 
 try:
     from openmdao.visualization.realtime_plot.realtime_plot_class import _RealTimePlot
@@ -910,7 +909,7 @@ class _RealTimeOptimizerPlot(_RealTimePlot):
             units = self._case_tracker._get_units(varname_minus_type)
             desvars_button_label = f"{varname} ({units})"
 
-            if upper_bound != INF_BOUND:
+            if upper_bound is not None and not np.isposinf(upper_bound):
                 upper_bound_indicator = self._make_bounds_display(
                     _bounds_infinity,
                     upper_bound,
@@ -926,7 +925,7 @@ class _RealTimeOptimizerPlot(_RealTimePlot):
                     visible=False,
                 )
 
-            if lower_bound != -INF_BOUND:
+            if lower_bound is not None and not np.isneginf(lower_bound):
                 lower_bound_indicator = self._make_bounds_display(
                     lower_bound,
                     -_bounds_infinity,

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -1,12 +1,13 @@
 
 """Define a function to view driver scaling."""
+import numbers
 import os
 import json
 import functools
 
 import numpy as np
 
-from openmdao.core.constants import _SetupStatus, INF_BOUND
+from openmdao.core.constants import _SetupStatus
 import openmdao.utils.hooks as hooks
 from openmdao.utils.webview import webview
 from openmdao.utils.general_utils import default_noraise
@@ -19,7 +20,7 @@ _default_scaling_filename = 'driver_scaling_report.html'
 def _getdef(val, unset):
     if val is None:
         return unset
-    if np.isscalar(val) and (val == INF_BOUND or val == -INF_BOUND):
+    if np.isscalar(val) and isinstance(val, numbers.Number) and np.isinf(val):
         return unset
     return val
 
@@ -36,7 +37,7 @@ def _get_flat(val, size, unset=''):
     if val is None:
         return val
     if np.isscalar(val):
-        if (val == INF_BOUND or val == -INF_BOUND):
+        if isinstance(val, numbers.Number) and np.isinf(val):
             val = unset
         return np.full(size, val)
     if val.size > 1:


### PR DESCRIPTION
### Summary

Infinite bounds are now stored as None in variable metadata (add_design_var, add_constraint) instead of ±1.0E30. The autoscaler converts None to ±np.inf on a per-element basis so that scaling arithmetic can operate uniformly across the bound array — np.inf propagates correctly through addition and multiplication, and the inf_mask logic skips those elements to avoid nan. The autoscaler therefore always returns ±np.inf for unbounded entries in its scaling.

Each driver converts ±np.inf to its optimizer's preferred representation via the class-level _inf_bound attribute and _to_driver_bound() method added to the Driver base class. pyOptSparseDriver overrides _inf_bound = 1.0E30 and intercepts all np.inf values in design variable and constraint bounds before passing them to addVarGroup/addConGroup, since SLSQP and other pyoptsparse-wrapped optimizers do not converge reliably with IEEE infinity. All other drivers inherit _inf_bound = np.inf.

find_feasible was also fixed: get_constraint_values(viol=True) now correctly handles None upper/lower bounds when computing constraint violations instead of raising a TypeError that was silently caught and falsely reported as feasible. The lm-method bounds warning check was similarly guarded against None comparisons.

INF_BOUND is retained in constants.py for backwards compatibility.

| Driver | _inf_bound | Reason |
| :--- | :--- | :--- |
| Driver (base) | `np.inf` | Default; pass-through for optimizers that accept IEEE infinity |
| pyOptSparseDriver | `1.0E30` | pyoptsparse SLSQP (and others) do not converge reliably with true infinity |
| ModOptDriver | `np.inf` (inherited) | modopt natively accepts `np.inf` |
| GeneticAlgorithmDriver | `np.inf` (inherited) | Reads meta['lower']/meta['upper'] directly; rejects unbounded vars as invalid |
| DifferentialEvolutionDriver | `np.inf` (inherited) | Same as GA driver |
| PymooDriver | `np.inf` (inherited) | Passes bounds directly; pymoo accepts `np.inf` |

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
